### PR TITLE
Accept `base_url` in Naver, Google and Defillama

### DIFF
--- a/datamaxi/defillama/__init__.py
+++ b/datamaxi/defillama/__init__.py
@@ -22,7 +22,7 @@ class Defillama(API):
         """
         if "base_url" not in kwargs:
             kwargs["base_url"] = BASE_URL
-            super().__init__(api_key, **kwargs)
+        super().__init__(api_key, **kwargs)
 
     def protocols(self) -> List[str]:
         """Get supported protocols

--- a/datamaxi/google/__init__.py
+++ b/datamaxi/google/__init__.py
@@ -18,7 +18,7 @@ class Google(API):
         """
         if "base_url" not in kwargs:
             kwargs["base_url"] = BASE_URL
-            super().__init__(api_key, **kwargs)
+        super().__init__(api_key, **kwargs)
 
     def keywords(self) -> List[str]:
         """Get Google trend supported keywords

--- a/datamaxi/naver/__init__.py
+++ b/datamaxi/naver/__init__.py
@@ -18,7 +18,7 @@ class Naver(API):
         """
         if "base_url" not in kwargs:
             kwargs["base_url"] = BASE_URL
-            super().__init__(api_key, **kwargs)
+        super().__init__(api_key, **kwargs)
 
     def keywords(self) -> List[str]:
         """Get Naver trend supported keywords


### PR DESCRIPTION
Previously, `base_url` parameter was not accepted due to code indentation.