### PR TITLE
snake_case query params: send top_n / min_volume_usd

### DIFF
--- a/datamaxi/_endpoints.py
+++ b/datamaxi/_endpoints.py
@@ -789,7 +789,7 @@ ENDPOINTS = {
                 "type": "str",
                 "description": "Base asset filter (case-insensitive)",
             },
-            "minVolumeUsd": {
+            "min_volume_usd": {
                 "required": False,
                 "type": "float",
                 "description": "Minimum VolumeUsd filter",
@@ -817,7 +817,7 @@ ENDPOINTS = {
                 "enum": ["1h", "4h", "24h"],
                 "description": "Rolling window",
             },
-            "topN": {
+            "top_n": {
                 "required": False,
                 "type": "int",
                 "default": 10,
@@ -872,7 +872,7 @@ ENDPOINTS = {
                 "type": "str",
                 "description": "Exchange filter",
             },
-            "minVolumeUsd": {
+            "min_volume_usd": {
                 "required": False,
                 "type": "float",
                 "description": "Minimum VolumeUsd filter",
@@ -1089,7 +1089,7 @@ ENDPOINTS = {
         "requires_auth": True,
         "group": "open_interest",
         "params": {
-            "topN": {
+            "top_n": {
                 "required": False,
                 "type": "int",
                 "default": 10,

--- a/datamaxi/datamaxi/liquidation.py
+++ b/datamaxi/datamaxi/liquidation.py
@@ -65,7 +65,7 @@ class Liquidation(API):
         if topN < 1 or topN > 30:
             raise ValueError("topN must be between 1 and 30")
         return self.query(
-            "/api/v1/liquidation/heatmap", {"window": window, "topN": topN}
+            "/api/v1/liquidation/heatmap", {"window": window, "top_n": topN}
         )
 
     def map(

--- a/datamaxi/datamaxi/open_interest.py
+++ b/datamaxi/datamaxi/open_interest.py
@@ -80,7 +80,7 @@ class OpenInterest(API):
         """
         if topN < 1 or topN > 30:
             raise ValueError("topN must be between 1 and 30")
-        return self.query("/api/v1/open-interest/summary", {"topN": topN})
+        return self.query("/api/v1/open-interest/summary", {"top_n": topN})
 
     def history_aggregated(
         self,

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -1,0 +1,51 @@
+"""
+Offline unit tests asserting the wire query-string keys for snake_case
+public params (top_n / min_volume_usd).
+
+Backend migrated these public params to snake_case canonical (dual-read).
+These tests pin that the SDK sends the snake_case keys on the wire, and
+that the user-facing ``topN`` kwarg stays accepted (non-breaking).
+"""
+
+import re
+import responses
+from urllib.parse import urlparse, parse_qs
+
+from datamaxi.datamaxi.liquidation import Liquidation
+from datamaxi.datamaxi.open_interest import OpenInterest
+
+BASE_URL = "https://api.datamaxiplus.com"
+
+
+def _query_of(call):
+    return parse_qs(urlparse(call.request.url).query)
+
+
+@responses.activate
+def test_liquidation_heatmap_sends_top_n():
+    responses.add(
+        responses.GET,
+        re.compile(".*/api/v1/liquidation/heatmap.*"),
+        json={},
+        status=200,
+    )
+    Liquidation(api_key="k", base_url=BASE_URL).heatmap(window="4h", topN=5)
+
+    qs = _query_of(responses.calls[0])
+    assert qs["top_n"] == ["5"]
+    assert "topN" not in qs
+
+
+@responses.activate
+def test_open_interest_summary_sends_top_n():
+    responses.add(
+        responses.GET,
+        re.compile(".*/api/v1/open-interest/summary.*"),
+        json={},
+        status=200,
+    )
+    OpenInterest(api_key="k", base_url=BASE_URL).summary(topN=7)
+
+    qs = _query_of(responses.calls[0])
+    assert qs["top_n"] == ["7"]
+    assert "topN" not in qs


### PR DESCRIPTION
## Summary
Aligns the Python SDK with the backend snake_case query-param migration (#7343 / PR #7356 / #7359, docs #7365). `top_n` / `min_volume_usd` are PERMANENT public params (data-api + MCP); the SDK was still sending the old camelCase keys.

Not an outage fix — backend dual-read still accepts camelCase. Canonical-alignment cleanup.

## Changes
- `liquidation.py` `heatmap()` wire key `topN` → `top_n`.
- `open_interest.py` `summary()` wire key `topN` → `top_n`.
- `_endpoints.py` metadata keys `topN` → `top_n` (×2), `minVolumeUsd` → `min_volume_usd` (×2).

## Design choice — Option A (keep public kwarg, snake_case only the wire key)
Kept the user-facing `topN` kwarg as-is and changed only the query-string key sent to the server. Zero breaking change; the issue explicitly allows user-facing names to stay. Renaming the kwarg would break existing callers for no behavioral gain. No SDK method exposes a `minVolumeUsd` kwarg, so only its metadata key needed renaming.

## `_endpoints.py` codegen finding
`_endpoints.py` is generated (`make python` from `openapi.yaml`) — the generator/spec live upstream in the backend repo, not in this repo, so there is no local regen path here. The backend OpenAPI source (`cmd/data-api/docs/openapi.yaml`) **already emits `top_n` / `min_volume_usd`** as of #7365; the committed `_endpoints.py` was simply regenerated before that update and went stale. This is a manual edit that catches the SDK up — the next `make python` run reconciles cleanly (it will reproduce these same snake_case keys). I did not fabricate a codegen run.

## Test plan
- Added `tests/test_query_params.py` — offline `responses`-mocked tests asserting `heatmap`/`summary` send `top_n` on the wire (and `topN` is absent).
- `python -m pytest tests/test_query_params.py tests/test_api.py -v` → 10 passed.
- `flake8 datamaxi/datamaxi/liquidation.py datamaxi/datamaxi/open_interest.py datamaxi/_endpoints.py tests/test_query_params.py` → clean.
- (Live tests in `test_call.py` / `test_integration.py` skip without `DATAMAXI_API_KEY`.)

Closes Bisonai/datamaxi-backend#7398
