### PR TITLE
fix(ci): drop abandoned pytest-pep8 from test requirements

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -2,7 +2,6 @@
 pytest-cov>=2.8.1
 pytest>=6.2.5
 responses>=0.10.12
-pytest-pep8>=1.0.6
 black==26.1.0
 flake8==7.3.0
 tox==4.34.1


### PR DESCRIPTION
Closes #81

## Summary
Remove `pytest-pep8>=1.0.6` from `requirements/requirements-test.txt`. The abandoned plugin (last release ~2014) registers a `pytest_collect_file(path, parent)` hook whose `path` arg modern pytest dropped from the hookspec, so pytest aborts at startup on py3.14 with `PluginValidationError` — the only matrix job that runs pytest (`if: matrix.python-version == '3.14'`). Nothing invokes `--pep8`; flake8 (7.3.0) already runs as its own CI step covering style.

## Test plan
- Grepped repo: no `--pep8` / pep8-marker usage anywhere (only the requirements line).
- Local venv (py3.12, pytest 9.1.1 / pluggy 1.6.0) with reqs minus pytest-pep8: `python -m pytest tests/` runs to completion — 8 passed, 151 skipped, no PluginValidationError.