### PR TITLE
ci: bump EOL GitHub Actions versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,12 +11,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ hashFiles('requirements/requirements-test.txt') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Install pypa/build


### PR DESCRIPTION
Closes #85

Bump Node16-EOL action majors to current: `actions/checkout@v3`→`v4`, `actions/setup-python@v4`→`v5`, `actions/cache@v3`→`v4` across python-package.yml, release.yml, docs.yml. Version-pin only, no other changes.

Test plan: CI runs green on this PR (no Node16 deprecation warnings).