### PR TITLE
chore(docs): unpin mkdocs-autorefs, bump mkdocstrings/griffe (#88)

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements-test.txt
 mkdocs==1.6.1
 mkdocs-material==9.7.1
-mkdocstrings==0.24.3
-mkdocstrings-python==1.9.0
-mkdocs-autorefs<1.0
-griffe==0.45.3
+mkdocstrings==1.0.4
+mkdocstrings-python==2.0.5
+mkdocs-autorefs==1.4.4
+griffe==2.1.0


### PR DESCRIPTION
Closes #88

Lifts the `mkdocs-autorefs<1.0` cap that was dragging the mkdocstrings/griffe line to old versions, and bumps the docs toolchain to current compatible releases.

### Version bumps (old -> new)
- mkdocstrings: 0.24.3 -> 1.0.4
- mkdocstrings-python: 1.9.0 -> 2.0.5
- mkdocs-autorefs: <1.0 -> ==1.4.4
- griffe: 0.45.3 -> 2.1.0

### Test plan
- Created a fresh venv (Python 3.12), `pip install -r requirements/requirements-dev.txt` (pins resolved cleanly, no downgrades).
- Ran `mkdocs build --strict` from repo root: exit 0, zero warnings/errors. This is the same toolchain used by `.github/workflows/docs.yml` (`mkdocs gh-deploy`).