### PR TITLE
fix(deps): loosen runtime dep pins to ranges in common.txt

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,3 +1,2 @@
-requests==2.32.5
-pandas==3.0.0; python_version >= "3.11"
-pandas==2.2.3; python_version < "3.11"
+requests>=2.31,<3
+pandas>=2.2,<4


### PR DESCRIPTION
## Summary

Loosen runtime dependency pins in `requirements/common.txt` (the file `pyproject.toml` exposes as the published runtime metadata via `dynamic = ["dependencies"]`). Exact `==` pins on a library force every downstream consumer to one version and cause pip resolver conflicts. Switched to compatible ranges; exact pins remain only in `requirements-dev.txt` / `requirements-test.txt` where reproducibility matters.

Closes #86

## What changed

`requirements/common.txt`:
```diff
-requests==2.32.5
-pandas==3.0.0; python_version >= "3.11"
-pandas==2.2.3; python_version < "3.11"
+requests>=2.31,<3
+pandas>=2.2,<4
```

## pandas version verification (PyPI)

- `pandas==3.0.0` **does exist** on PyPI (latest is 3.0.4). So the old pin was not broken-on-its-face, but exact-pinning is still wrong for a library.
- pandas `3.0.0` declares `requires-python >=3.11`; pandas `2.2` declares `>=3.9`.
- Project's `requires-python = ">=3.10"`. The two python_version-marked lines collapse into a single range `pandas>=2.2,<4`: pip's resolver honors each wheel's `requires-python`, so on Python 3.10 it auto-skips 3.0.x and resolves a compatible 2.x, while 3.11+ gets the latest 3.0.x. No environment markers needed.
- `requests`: latest is 2.34.x, all `<3`; floor `2.31` is a sensible compatible floor.

## Test plan

- `requirements/common.txt` lines parse via `packaging.requirements.Requirement`.
- Fresh venv (Python 3.12) `pip install .` succeeds; resolves pandas 3.0.3 + requests 2.34.2; `import datamaxi` OK.
- `pytest -p no:pep8`: **10 passed, 151 skipped** (skips require live API creds). The `pytest-pep8` plugin errors on collection due to a pre-existing incompatibility with modern pytest — unrelated to this change.
- Full CI matrix (py3.10–3.14) not reproduced locally; only Python 3.12 verified here.
