### PR TITLE
chore: modernize stale test-dep floors (pytest>=8, pytest-cov>=5, responses>=0.25)

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,7 +1,7 @@
 -r common.txt
-pytest-cov>=2.8.1
-pytest>=6.2.5
-responses>=0.10.12
+pytest-cov>=5
+pytest>=8
+responses>=0.25
 black==26.1.0
 flake8==7.3.0
 tox==4.34.1


### PR DESCRIPTION
Closes #87

Bumps stale 2019–2021-era test-requirement floors in `requirements/requirements-test.txt` to currently-supported majors:

- `pytest>=6.2.5` -> `pytest>=8`
- `pytest-cov>=2.8.1` -> `pytest-cov>=5`
- `responses>=0.10.12` -> `responses>=0.25`

No upper caps (matches existing capless style). `pytest-pep8` line left untouched (handled by #82); black/flake8/tox/tox-pyenv/wheel pins unchanged.

## Test plan
Fresh venv (Python 3.12.7), `pip install -r requirements/requirements-test.txt`, resolved: pytest 9.1.1, pytest-cov 7.1.0, responses 0.26.1.

`python -m pytest tests/`: **10 passed, 151 skipped** (skips are live-API integration tests gated on `DATAMAXI_API_KEY`; responses-mocked suite passes). No old pytest-era API breakage.