### PR TITLE
Remove dead/broken tox stack (tox.ini + tox + tox-pyenv)

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -4,6 +4,4 @@ pytest>=8
 responses>=0.25
 black==26.1.0
 flake8==7.3.0
-tox==4.34.1
-tox-pyenv==1.1.0
 wheel==0.46.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ markers =
 [flake8]
 exclude =
     .git,
-    .tox,
     build,
     dist
 max-complexity = 10

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[tox]
-envlist = py38,py39,310,311
-
-[testenv]
-deps =
-    -rrequirements/requirements-test.txt
-commands =
-    pytest


### PR DESCRIPTION
## Summary

Deletes the dead/broken tox setup (same class as #81). CI (`.github/workflows/python-package.yml`) runs `black`/`flake8`/`pytest` directly and never invokes tox, so this is unused weight; `tox-pyenv==1.1.0` is abandoned and broken against tox 4 (implements the removed `tox_get_python_executable` hook), and `tox.ini`'s envlist was stale/malformed (`py38,py39,310,311`).

- Remove `tox.ini`
- Drop `tox` + `tox-pyenv` from `requirements/requirements-test.txt`
- Drop `.tox` from `[flake8] exclude` in `setup.cfg`

No application code touched.

## Test plan
- `flake8 . --statistics` → clean (exit 0)
- `black --check --diff .` → clean (28 files unchanged)
- `python -m pytest tests/` → 124 passed, 13 xpassed, 3 failed. The 3 failures are pre-existing live-endpoint flakiness (ReadTimeout / "no data found" from prod data), unrelated to this change — these are exactly the live-prod tests CI deliberately skips.

Closes #84