### PR TITLE
Adopt uv for dev + CI install

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,14 +16,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v4
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v6
       with:
-        path: ~/.cache/pip
-        key: ${{ hashFiles('requirements/requirements-test.txt') }}
+        enable-cache: true
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements/requirements-test.txt
+      run: uv pip install --system -r requirements/requirements-test.txt
     - name: Run black to review standard code format
       run: |
         # Checks if need to reformat files

--- a/README.md
+++ b/README.md
@@ -410,35 +410,45 @@ data3, next_request3 = next_request2()
 
 ## Local Development
 
+This project uses [uv](https://docs.astral.sh/uv/) for fast dev setup. Install
+uv first (see the [uv docs](https://docs.astral.sh/uv/getting-started/installation/)).
+
 ```shell
 git clone https://github.com/bisonai/datamaxi-python.git
 cd datamaxi-python
-pip install -r requirements/common.txt
+
+# Create a virtual environment and install dev dependencies
+# (requirements-dev.txt pulls in the test and docs stacks).
+uv venv
+uv pip install -r requirements/requirements-dev.txt
+
+# For runtime dependencies only:
+# uv pip install -r requirements/common.txt
 ```
 
 ## Tests
 
 ```shell
-# Install test dependencies
-pip install -r requirements/requirements-test.txt
+# Install test dependencies (skip if you already ran the dev install above)
+uv pip install -r requirements/requirements-test.txt
 
 # Run unit tests (no API key required)
-python -m pytest tests/test_api.py -v
+uv run pytest tests/test_api.py -v
 
 # Run integration tests (requires API key)
 export DATAMAXI_API_KEY="your_api_key"
-python -m pytest tests/test_integration.py -v
+uv run pytest tests/test_integration.py -v
 
 # Test specific endpoint groups using markers
-python -m pytest tests/test_integration.py -m "cex" -v
-python -m pytest tests/test_integration.py -m "funding" -v
-python -m pytest tests/test_integration.py -m "premium" -v
-python -m pytest tests/test_integration.py -m "forex" -v
-python -m pytest tests/test_integration.py -m "telegram" -v
-python -m pytest tests/test_integration.py -m "naver" -v
+uv run pytest tests/test_integration.py -m "cex" -v
+uv run pytest tests/test_integration.py -m "funding" -v
+uv run pytest tests/test_integration.py -m "premium" -v
+uv run pytest tests/test_integration.py -m "forex" -v
+uv run pytest tests/test_integration.py -m "telegram" -v
+uv run pytest tests/test_integration.py -m "naver" -v
 
 # Run all tests
-python -m pytest tests/ -v
+uv run pytest tests/ -v
 ```
 
 ## Links


### PR DESCRIPTION
Closes #100

## Summary
Speed up contributor setup and CI by using `uv` for installs, keeping the existing `requirements/*.txt` layout (no deps moved into `pyproject.toml`, no committed `uv.lock`).

- **CI** (`.github/workflows/python-package.yml`): add `astral-sh/setup-uv@v6` (with `enable-cache: true`) and replace the pip install step with `uv pip install --system -r requirements/requirements-test.txt`. Dropped the now-redundant `actions/cache@v4` pip-cache step (uv provides its own cache). Matrix, black, flake8, and the offline mocked-test step are unchanged.
- **Docs** (`README.md`): Local Development + Tests now use `uv venv` / `uv pip install` / `uv run pytest`, with a link to the uv docs. Integration tests still require `DATAMAXI_API_KEY`.

Note: tox was already removed upstream (#98), so nothing to do there.

## Test plan
- CI will validate the uv-based install across the py3.10–3.14 matrix (black + flake8 + offline mocked tests).
- Live integration tests still run locally only (`DATAMAXI_API_KEY=... pytest tests/`); not run in CI.
- Verified locally: workflow YAML parses (`yaml.safe_load`), no remaining `tox` references, only `.github/workflows/python-package.yml` and `README.md` changed (no `.py` edits, so black/flake8 unaffected).