### PR TITLE
ci: skip CI on docs-only changes via paths-ignore

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,6 +1,12 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Adds a `paths-ignore` filter to the `push` trigger in `.github/workflows/python-package.yml` so pushes that touch **only** docs/markdown/LICENSE/.gitignore skip the workflow. Any change to code, tests, requirements, or the workflow file itself still runs the full 5-version matrix (3.10–3.14).

```yaml
on:
  push:
    paths-ignore:
      - '**.md'
      - 'docs/**'
      - 'LICENSE'
      - '.gitignore'
```

The `build` job, matrix, and all steps are unchanged — only the trigger block was modified.

## Rationale: `paths-ignore` (blocklist) vs `paths` (allowlist)

`paths-ignore` fails safe: any new or unanticipated code path still triggers CI. A `paths` allowlist would silently skip CI for any path someone forgot to add. The ignore list is deliberately limited to files that genuinely cannot affect the lint checks (black/flake8 only run on `.py`): markdown, the `docs/**` tree (verified: only `.md`/css/images, no Python), `LICENSE`, and `.gitignore`.

## Branch protection

`main` has no branch protection (verified: `repos/Bisonai/datamaxi-python/branches/main/protection` → 404), so a skipped workflow leaves no required-check pending. No no-op fallback job is needed; a plain `paths-ignore` filter is sufficient.

## Test / validation plan

- YAML validated with `yaml.safe_load` (parses OK).
- Diff confirmed scoped: only the `on:` trigger block changed; job/matrix/steps untouched.
- To confirm behavior after merge: a docs-only push (e.g. editing `README.md`) should not trigger `python-package.yml`; a push touching any `.py`/requirements/workflow file should still run the full matrix.

Closes #104
