### PR TITLE
fix(pkg): make lib a real package; clean before local build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: clean build
+
+# Remove build artifacts so stale modules can't leak into the wheel.
+clean:
+	rm -rf build dist *.egg-info datamaxi.egg-info
+
+# Always build from a clean tree (matches the fresh-checkout CI build).
+build: clean
+	python -m build


### PR DESCRIPTION
## Summary
Two packaging fixes found while auditing `MANIFEST.in`.

- **`datamaxi/lib/__init__.py`** — `lib` (heavily imported: `datamaxi.lib.utils`, `datamaxi.lib.constants`) had no `__init__.py`, so it only shipped as an implicit namespace package. Made it an explicit package for robustness.
- **`Makefile`** — `clean` + `build` targets. `build` cleans first so a stale `build/` dir can't leak removed/phantom modules into a locally-built wheel.

### Why
A leftover `build/` dir (Apr 2024) caused `python -m build --wheel` to ship phantom packages (`binance/`, `google/`, `defillama/`, `examples/`) that no longer exist in source — `bdist_wheel` zips `build/lib`, and `build_py` copies current files in without removing old ones. The sdist was unaffected. **CI (`release.yml`) is safe** — it builds on a fresh `checkout@v4`, so no stale `build/` exists; this only bit local builds.

`MANIFEST.in` itself needs no changes — `requirements/common.txt` (build-time dep source) is already included and the sdist builds correctly.

## Tests
- `pytest -m "not integration"`: **108 passed, 130 skipped**.
- `make build` then inspected wheel: 23 correct modules + `lib/__init__.py`, no phantoms.

## Known failures
None.