### PR TITLE
docs: document liquidation, open_interest, and cex.symbol surfaces

### DIFF
--- a/docs/cex-symbol.md
+++ b/docs/cex-symbol.md
@@ -1,0 +1,45 @@
+# CEX Symbol
+
+Per-base / per-symbol CEX metadata and aggregates: trading status, tags, cautions, delistings, volume, Open Interest, and liquidation.
+
+## Usage
+
+```python
+from datamaxi import Datamaxi
+
+maxi = Datamaxi(api_key="YOUR_API_KEY")
+
+# Trading status + caution + tags + delisting metadata
+metadata = maxi.cex.symbol.metadata(exchange="binance", base="BTC")
+
+# Exchange-assigned tags (e.g. seed, alpha)
+tags = maxi.cex.symbol.tags(exchange="binance", base="BTC")
+
+# Active caution / investment-warning flags
+cautions = maxi.cex.symbol.cautions(exchange="binance", base="BTC")
+
+# Scheduled delistings with timestamps
+delistings = maxi.cex.symbol.delistings(exchange="binance", base="BTC")
+
+# Per-exchange 24h volume for a single base asset
+volume = maxi.cex.symbol.volume(base="BTC", exchange="binance")
+
+# Per-exchange Open Interest for a single base asset
+oi = maxi.cex.symbol.oi(base="BTC", exchange="binance")
+
+# Per-exchange OI snapshot with 1h / 4h / 24h deltas
+oi_stats = maxi.cex.symbol.oi_stats(base="BTC", exchange="binance", currency="USD")
+
+# Per-exchange long / short liquidation aggregates over a window
+liquidation = maxi.cex.symbol.liquidation(base="BTC", window="24h")
+```
+
+## Notes
+
+- `metadata`, `tags`, `cautions`, and `delistings` take optional `exchange` / `base` filters; omit both to fetch across all symbols.
+- `oi_stats` accepts `currency` of `USD` or `KRW`.
+
+::: datamaxi.datamaxi.CexSymbol
+    options:
+      show_submodules: true
+      show_source: false

--- a/docs/liquidation.md
+++ b/docs/liquidation.md
@@ -1,0 +1,42 @@
+# Liquidation
+
+CEX futures liquidation data: recent events, firehose feed, heatmaps, maps, and bucketed history.
+
+## Usage
+
+```python
+from datamaxi import Datamaxi
+
+maxi = Datamaxi(api_key="YOUR_API_KEY")
+
+# Recent liquidation events for a single futures symbol
+events = maxi.liquidation(exchange="binance", symbol="BTC-USDT", limit=100)
+
+# Firehose: most recent events across every symbol
+feed = maxi.liquidation.feed(limit=100)
+
+# Token x exchange liquidation heatmap over a rolling window
+heatmap = maxi.liquidation.heatmap(window="1h", topN=10)
+
+# Coinglass-style liquidation map (price x leverage tier)
+liq_map = maxi.liquidation.map(base="BTC", exchange="binance", quote="USDT")
+
+# Bucketed long / short liquidation USD time series + price line
+history = maxi.liquidation.symbol_history(
+    symbol="BTC",
+    quote="USDT",
+    exchange="binance",
+    interval="5m",
+    window="24h",
+)
+```
+
+## Notes
+
+- `heatmap` accepts `window` of `1h`, `4h`, or `24h`; `topN` must be between 1 and 30.
+- `symbol_history` accepts `interval` of `5m`, `15m`, or `1h` and `window` of `24h`, `72h`, or `7d`.
+
+::: datamaxi.datamaxi.Liquidation
+    options:
+      show_submodules: true
+      show_source: false

--- a/docs/open-interest.md
+++ b/docs/open-interest.md
@@ -1,0 +1,44 @@
+# Open Interest
+
+CEX futures Open Interest: latest snapshots, reporting pairs, the token x exchange matrix, top-line aggregates, and aggregated history.
+
+## Usage
+
+```python
+from datamaxi import Datamaxi
+
+maxi = Datamaxi(api_key="YOUR_API_KEY")
+
+# Latest OI snapshot for a single futures symbol
+snapshot = maxi.open_interest(exchange="binance", symbol="BTC-USDT")
+
+# List all (exchange, symbol) pairs currently reporting OI
+pairs = maxi.open_interest.list(exchange="binance")
+
+# Paginated token x exchange OI matrix
+overview = maxi.open_interest.overview(
+    page=1,
+    limit=20,
+    key="binance",
+    sort="desc",
+)
+
+# Top-line OI aggregates (total USD, top tokens, top exchanges)
+summary = maxi.open_interest.summary(topN=10)
+
+# Per-exchange aggregated OI history for a single token
+history = maxi.open_interest.history_aggregated(
+    token_id="bitcoin",
+    interval="1h",
+)
+```
+
+## Notes
+
+- `overview` requires `sort` to be `asc` or `desc`; `summary` accepts `topN` between 1 and 30.
+- `history_aggregated` uses the token id (e.g. `bitcoin`), not a ticker, and accepts `interval` of `5m`, `15m`, `1h`, `4h`, or `1d`. Pass `from_` / `to` as unix-ms (`from_` maps to the wire param `from`).
+
+::: datamaxi.datamaxi.OpenInterest
+    options:
+      show_submodules: true
+      show_source: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,10 @@ nav:
       - Wallet Status: cex-wallet-status.md
       - Announcement: cex-announcement.md
       - Token: cex-token.md
+      - Symbol: cex-symbol.md
   - Funding Rate: funding-rate.md
+  - Liquidation: liquidation.md
+  - Open Interest: open-interest.md
   - Premium: premium.md
   - Forex: forex.md
   - Naver Trend: naver-trend.md


### PR DESCRIPTION
Closes #108

## Summary

Three public client surfaces had no docs. Adds doc pages + nav entries, basing every snippet on the actual method signatures in code.

- `docs/liquidation.md` — `::: datamaxi.datamaxi.Liquidation` (`client.liquidation`): `__call__`, `feed`, `heatmap`, `map`, `symbol_history`
- `docs/open-interest.md` — `::: datamaxi.datamaxi.OpenInterest` (`client.open_interest`): `__call__`, `list`, `overview`, `summary`, `history_aggregated`
- `docs/cex-symbol.md` — `::: datamaxi.datamaxi.CexSymbol` (`client.cex.symbol`): `metadata`, `tags`, `cautions`, `delistings`, `volume`, `oi`, `oi_stats`, `liquidation`
- `mkdocs.yml`: top-level `Liquidation` + `Open Interest`; `Symbol` under the `CEX:` group.

Structure mirrors existing pages (funding-rate.md etc.): intro + usage snippet + mkdocstrings block. Drift sweep: no DEX refs remain; all method references in existing pages verified against source — no stale/renamed signatures found, so no other changes.

## Test plan

- Installed docs deps from `requirements/requirements-dev.txt` + editable package into a venv.
- Ran `mkdocs build --strict` from the worktree root: built in ~10s, **exit 0, zero warnings** (strict fails on any missing mkdocstrings reference, so the three `:::` blocks resolve).
- No code changed; offline pytest suite not applicable (docs-only).