### PR TITLE
fix(deps): bump black to 26.3.1 (Dependabot high)

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -2,6 +2,6 @@
 pytest-cov>=5
 pytest>=8
 responses>=0.25
-black==26.1.0
+black==26.3.1
 flake8==7.3.0
 wheel==0.46.3


### PR DESCRIPTION
Resolves 2 open Dependabot high-severity alerts (#2, #5): *Black — arbitrary file writes from unsanitized input in cache file name* (`black < 26.3.1`).

- Bump `black` `26.1.0` → `26.3.1` in `requirements/requirements-test.txt`.

Dev-only tooling (formatter), not a runtime dependency.

## Tests
No code changes; lint/test tooling only. CI flake8+black run will exercise the new pin.

## Known failures
None.