### PR TITLE
Roll out codegen registry to all client classes (#114)

### DIFF
--- a/datamaxi/datamaxi/cex_announcement.py
+++ b/datamaxi/datamaxi/cex_announcement.py
@@ -50,16 +50,15 @@ class CexAnnouncement(API):
         if sort not in [ASC, DESC]:
             raise ValueError("sort must be either asc or desc")
 
-        params = {
-            "page": page,
-            "limit": limit,
-            "sort": sort,
-            "key": key,
-            "exchange": exchange,
-            "category": category,
-        }
-
-        res = self.query("/api/v1/cex/announcements", params)
+        res = self.request_endpoint(
+            "cex_announcements",
+            page=page,
+            limit=limit,
+            sort=sort,
+            key=key,
+            exchange=exchange,
+            category=category,
+        )
         if res["data"] is None:
             raise ValueError("no data found")
 

--- a/datamaxi/datamaxi/cex_fee.py
+++ b/datamaxi/datamaxi/cex_fee.py
@@ -33,14 +33,7 @@ class CexFee(API):
         Returns:
             Trading fee data
         """
-        params = {}
-        if exchange:
-            params["exchange"] = exchange
-        if symbol:
-            params["symbol"] = symbol
-
-        url_path = "/api/v1/cex/fees"
-        return self.query(url_path, params)
+        return self.request_endpoint("cex_fees", exchange=exchange, symbol=symbol)
 
     def exchanges(self) -> List[str]:
         """Fetch supported exchanges for fee data.
@@ -52,8 +45,7 @@ class CexFee(API):
         Returns:
             List of supported exchanges
         """
-        url_path = "/api/v1/cex/fees/exchanges"
-        return self.query(url_path)
+        return self.request_endpoint("cex_fees_exchanges")
 
     def symbols(self, exchange: str) -> List[str]:
         """Fetch supported symbols for fee data.
@@ -70,9 +62,4 @@ class CexFee(API):
         """
         check_required_parameter(exchange, "exchange")
 
-        params = {
-            "exchange": exchange,
-        }
-
-        url_path = "/api/v1/cex/fees/symbols"
-        return self.query(url_path, params)
+        return self.request_endpoint("cex_fees_symbols", exchange=exchange)

--- a/datamaxi/datamaxi/cex_symbol.py
+++ b/datamaxi/datamaxi/cex_symbol.py
@@ -32,9 +32,7 @@ class CexSymbol(API):
 
         `GET /api/v1/cex/symbol/tags`
         """
-        return self.request_endpoint(
-            "cex_symbol_tags", exchange=exchange, base=base
-        )
+        return self.request_endpoint("cex_symbol_tags", exchange=exchange, base=base)
 
     def cautions(
         self, exchange: Optional[str] = None, base: Optional[str] = None
@@ -79,9 +77,7 @@ class CexSymbol(API):
 
         `GET /api/v1/cex/symbol/oi`
         """
-        return self.request_endpoint(
-            "cex_symbol_oi", base=base, exchange=exchange
-        )
+        return self.request_endpoint("cex_symbol_oi", base=base, exchange=exchange)
 
     def oi_stats(
         self,
@@ -116,6 +112,4 @@ class CexSymbol(API):
             base (str): Base asset (e.g. ``BTC``).
             window (str): Time window (``1h``, ``24h``, ``7d`` — server caps at 30d).
         """
-        return self.request_endpoint(
-            "cex_symbol_liquidation", base=base, window=window
-        )
+        return self.request_endpoint("cex_symbol_liquidation", base=base, window=window)

--- a/datamaxi/datamaxi/cex_symbol.py
+++ b/datamaxi/datamaxi/cex_symbol.py
@@ -21,12 +21,9 @@ class CexSymbol(API):
 
         `GET /api/v1/cex/symbol/metadata`
         """
-        params: Dict[str, Any] = {}
-        if exchange is not None:
-            params["exchange"] = exchange
-        if base is not None:
-            params["base"] = base
-        return self.query("/api/v1/cex/symbol/metadata", params)
+        return self.request_endpoint(
+            "cex_symbol_metadata", exchange=exchange, base=base
+        )
 
     def tags(
         self, exchange: Optional[str] = None, base: Optional[str] = None
@@ -35,12 +32,9 @@ class CexSymbol(API):
 
         `GET /api/v1/cex/symbol/tags`
         """
-        params: Dict[str, Any] = {}
-        if exchange is not None:
-            params["exchange"] = exchange
-        if base is not None:
-            params["base"] = base
-        return self.query("/api/v1/cex/symbol/tags", params)
+        return self.request_endpoint(
+            "cex_symbol_tags", exchange=exchange, base=base
+        )
 
     def cautions(
         self, exchange: Optional[str] = None, base: Optional[str] = None
@@ -85,10 +79,9 @@ class CexSymbol(API):
 
         `GET /api/v1/cex/symbol/oi`
         """
-        params: Dict[str, Any] = {"base": base}
-        if exchange is not None:
-            params["exchange"] = exchange
-        return self.query("/api/v1/cex/symbol/oi", params)
+        return self.request_endpoint(
+            "cex_symbol_oi", base=base, exchange=exchange
+        )
 
     def oi_stats(
         self,
@@ -107,10 +100,12 @@ class CexSymbol(API):
         """
         if currency not in ("USD", "KRW"):
             raise ValueError("currency must be either USD or KRW")
-        params: Dict[str, Any] = {"base": base, "currency": currency}
-        if exchange is not None:
-            params["exchange"] = exchange
-        return self.query("/api/v1/cex/symbol/oi-stats", params)
+        return self.request_endpoint(
+            "cex_symbol_oi_stats",
+            base=base,
+            exchange=exchange,
+            currency=currency,
+        )
 
     def liquidation(self, base: str, window: str = "24h") -> Dict[str, Any]:
         """Per-exchange long / short liquidation aggregates over a window.
@@ -121,6 +116,6 @@ class CexSymbol(API):
             base (str): Base asset (e.g. ``BTC``).
             window (str): Time window (``1h``, ``24h``, ``7d`` — server caps at 30d).
         """
-        return self.query(
-            "/api/v1/cex/symbol/liquidation", {"base": base, "window": window}
+        return self.request_endpoint(
+            "cex_symbol_liquidation", base=base, window=window
         )

--- a/datamaxi/datamaxi/cex_ticker.py
+++ b/datamaxi/datamaxi/cex_ticker.py
@@ -55,19 +55,14 @@ class CexTicker(API):
         if market not in [SPOT, FUTURES]:
             raise ValueError("market must be either spot or futures")
 
-        params = {
-            "exchange": exchange,
-            "symbol": symbol,
-            "market": market,
-        }
-
-        if currency is not None:
-            params["currency"] = currency
-
-        if conversion_base is not None:
-            params["conversion_base"] = conversion_base
-
-        res = self.query("/api/v1/ticker", params)
+        res = self.request_endpoint(
+            "ticker",
+            exchange=exchange,
+            symbol=symbol,
+            market=market,
+            currency=currency,
+            conversion_base=conversion_base,
+        )
 
         if pandas:
             df = pd.DataFrame([res["data"]])
@@ -101,12 +96,7 @@ class CexTicker(API):
         if market not in [SPOT, FUTURES]:
             raise ValueError("market must be either spot or futures")
 
-        params = {
-            "market": market,
-        }
-
-        url_path = "/api/v1/ticker/exchanges"
-        return self.query(url_path, params)
+        return self.request_endpoint("ticker_exchanges", market=market)
 
     def symbols(
         self,
@@ -136,10 +126,6 @@ class CexTicker(API):
         if market not in [SPOT, FUTURES]:
             raise ValueError("market must be either spot or futures")
 
-        params = {
-            "exchange": exchange,
-            "market": market,
-        }
-
-        url_path = "/api/v1/ticker/symbols"
-        return self.query(url_path, params)
+        return self.request_endpoint(
+            "ticker_symbols", exchange=exchange, market=market
+        )

--- a/datamaxi/datamaxi/cex_ticker.py
+++ b/datamaxi/datamaxi/cex_ticker.py
@@ -126,6 +126,4 @@ class CexTicker(API):
         if market not in [SPOT, FUTURES]:
             raise ValueError("market must be either spot or futures")
 
-        return self.request_endpoint(
-            "ticker_symbols", exchange=exchange, market=market
-        )
+        return self.request_endpoint("ticker_symbols", exchange=exchange, market=market)

--- a/datamaxi/datamaxi/cex_wallet_status.py
+++ b/datamaxi/datamaxi/cex_wallet_status.py
@@ -44,9 +44,7 @@ class CexWalletStatus(API):
             ]
         )
 
-        res = self.request_endpoint(
-            "wallet_status", exchange=exchange, asset=asset
-        )
+        res = self.request_endpoint("wallet_status", exchange=exchange, asset=asset)
         if pandas:
             df = pd.DataFrame(res)
             df = df.set_index("network")

--- a/datamaxi/datamaxi/cex_wallet_status.py
+++ b/datamaxi/datamaxi/cex_wallet_status.py
@@ -44,13 +44,9 @@ class CexWalletStatus(API):
             ]
         )
 
-        params = {
-            "exchange": exchange,
-            "asset": asset,
-        }
-
-        url_path = "/api/v1/wallet-status"
-        res = self.query(url_path, params)
+        res = self.request_endpoint(
+            "wallet_status", exchange=exchange, asset=asset
+        )
         if pandas:
             df = pd.DataFrame(res)
             df = df.set_index("network")
@@ -68,8 +64,7 @@ class CexWalletStatus(API):
         Returns:
             List of supported exchange
         """
-        url_path = "/api/v1/wallet-status/exchanges"
-        return self.query(url_path)
+        return self.request_endpoint("wallet_status_exchanges")
 
     def assets(self, exchange: str) -> List[str]:
         """Fetch supported assets for wallet status data.
@@ -86,9 +81,4 @@ class CexWalletStatus(API):
         """
         check_required_parameter(exchange, "exchange")
 
-        params = {
-            "exchange": exchange,
-        }
-
-        url_path = "/api/v1/wallet-status/assets"
-        return self.query(url_path, params)
+        return self.request_endpoint("wallet_status_assets", exchange=exchange)

--- a/datamaxi/datamaxi/forex.py
+++ b/datamaxi/datamaxi/forex.py
@@ -39,11 +39,7 @@ class Forex(API):
         """
         check_required_parameter(symbol, "symbol")
 
-        params = {
-            "symbol": symbol,
-        }
-
-        res = self.query("/api/v1/forex", params)
+        res = self.request_endpoint("forex", symbol=symbol)
 
         if pandas:
             return pd.DataFrame([res])
@@ -60,5 +56,4 @@ class Forex(API):
         Returns:
             List of supported symbols
         """
-        url_path = "/api/v1/forex/symbols"
-        return self.query(url_path)
+        return self.request_endpoint("forex_symbols")

--- a/datamaxi/datamaxi/funding_rate.py
+++ b/datamaxi/datamaxi/funding_rate.py
@@ -70,17 +70,15 @@ class FundingRate(API):
         if sort not in [ASC, DESC]:
             raise ValueError("sort must be either asc or desc")
 
-        params = {
-            "exchange": exchange,
-            "symbol": symbol,
-            "page": page,
-            "limit": limit,
-            "from": fromDateTime,
-            "to": toDateTime,
-            "sort": sort,
-        }
-
-        res = self.query("/api/v1/funding-rate/history", params)
+        res = self.request_endpoint(
+            "funding_rate_history",
+            exchange=exchange,
+            symbol=symbol,
+            page=page,
+            limit=limit,
+            sort=sort,
+            **{"from": fromDateTime, "to": toDateTime},
+        )
         if res["data"] is None or len(res["data"]) == 0:
             raise ValueError("no data found")
 
@@ -159,8 +157,7 @@ class FundingRate(API):
         Returns:
             List of supported exchanges
         """
-        url_path = "/api/v1/funding-rate/exchanges"
-        return self.query(url_path)
+        return self.request_endpoint("funding_rate_exchanges")
 
     def symbols(self, exchange: str) -> List[str]:
         """Fetch supported symbols for funding rate endpoints.
@@ -176,6 +173,4 @@ class FundingRate(API):
             List of supported symbols
         """
         check_required_parameter(exchange, "exchange")
-        params = {"exchange": exchange}
-        url_path = "/api/v1/funding-rate/symbols"
-        return self.query(url_path, params)
+        return self.request_endpoint("funding_rate_symbols", exchange=exchange)

--- a/datamaxi/datamaxi/liquidation.py
+++ b/datamaxi/datamaxi/liquidation.py
@@ -65,9 +65,7 @@ class Liquidation(API):
         """
         if topN < 1 or topN > 30:
             raise ValueError("topN must be between 1 and 30")
-        return self.request_endpoint(
-            "liquidation_heatmap", window=window, top_n=topN
-        )
+        return self.request_endpoint("liquidation_heatmap", window=window, top_n=topN)
 
     def map(
         self,

--- a/datamaxi/datamaxi/liquidation.py
+++ b/datamaxi/datamaxi/liquidation.py
@@ -34,8 +34,9 @@ class Liquidation(API):
         """
         if limit < 1:
             raise ValueError("limit must be greater than 0")
-        params = {"exchange": exchange, "symbol": symbol, "limit": limit}
-        return self.query("/api/v1/liquidation", params)
+        return self.request_endpoint(
+            "liquidation", exchange=exchange, symbol=symbol, limit=limit
+        )
 
     def feed(self, limit: int = 100) -> Dict[str, Any]:
         """Firehose: most recent liquidation events across every symbol.
@@ -47,7 +48,7 @@ class Liquidation(API):
         """
         if limit < 1:
             raise ValueError("limit must be greater than 0")
-        return self.query("/api/v1/liquidation/feed", {"limit": limit})
+        return self.request_endpoint("liquidation_feed", limit=limit)
 
     def heatmap(
         self,
@@ -64,8 +65,8 @@ class Liquidation(API):
         """
         if topN < 1 or topN > 30:
             raise ValueError("topN must be between 1 and 30")
-        return self.query(
-            "/api/v1/liquidation/heatmap", {"window": window, "top_n": topN}
+        return self.request_endpoint(
+            "liquidation_heatmap", window=window, top_n=topN
         )
 
     def map(
@@ -83,8 +84,9 @@ class Liquidation(API):
             exchange (str): Exchange (default ``binance``).
             quote (str): Quote asset (default ``USDT``).
         """
-        params = {"base": base, "exchange": exchange, "quote": quote}
-        return self.query("/api/v1/liquidation/map", params)
+        return self.request_endpoint(
+            "liquidation_map", base=base, exchange=exchange, quote=quote
+        )
 
     def symbol_history(
         self,
@@ -106,12 +108,11 @@ class Liquidation(API):
             interval (str): Bucket interval (``5m``, ``15m``, or ``1h``).
             window (str): Lookback window (``24h``, ``72h``, or ``7d``).
         """
-        params = {
-            "symbol": symbol,
-            "quote": quote,
-            "interval": interval,
-            "window": window,
-        }
-        if exchange is not None:
-            params["exchange"] = exchange
-        return self.query("/api/v1/liquidation/symbol-history", params)
+        return self.request_endpoint(
+            "liquidation_symbol_history",
+            symbol=symbol,
+            quote=quote,
+            exchange=exchange,
+            interval=interval,
+            window=window,
+        )

--- a/datamaxi/datamaxi/open_interest.py
+++ b/datamaxi/datamaxi/open_interest.py
@@ -23,9 +23,7 @@ class OpenInterest(API):
             exchange (str): Exchange (e.g. ``binance``).
             symbol (str): Exchange-native API symbol (e.g. ``BTC-USDT``).
         """
-        return self.request_endpoint(
-            "open_interest", exchange=exchange, symbol=symbol
-        )
+        return self.request_endpoint("open_interest", exchange=exchange, symbol=symbol)
 
     def list(self, exchange: Optional[str] = None) -> Dict[str, Any]:
         """List all (exchange, symbol) pairs currently reporting OI.

--- a/datamaxi/datamaxi/open_interest.py
+++ b/datamaxi/datamaxi/open_interest.py
@@ -23,8 +23,8 @@ class OpenInterest(API):
             exchange (str): Exchange (e.g. ``binance``).
             symbol (str): Exchange-native API symbol (e.g. ``BTC-USDT``).
         """
-        return self.query(
-            "/api/v1/open-interest", {"exchange": exchange, "symbol": symbol}
+        return self.request_endpoint(
+            "open_interest", exchange=exchange, symbol=symbol
         )
 
     def list(self, exchange: Optional[str] = None) -> Dict[str, Any]:
@@ -35,10 +35,7 @@ class OpenInterest(API):
         Args:
             exchange (str): Optional filter to one exchange.
         """
-        params = {}
-        if exchange is not None:
-            params["exchange"] = exchange
-        return self.query("/api/v1/open-interest/list", params)
+        return self.request_endpoint("open_interest_list", exchange=exchange)
 
     def overview(
         self,
@@ -65,10 +62,14 @@ class OpenInterest(API):
             raise ValueError("limit must be greater than 0")
         if sort not in ("asc", "desc"):
             raise ValueError("sort must be either asc or desc")
-        params = {"page": page, "limit": limit, "key": key, "sort": sort}
-        if query is not None:
-            params["query"] = query
-        return self.query("/api/v1/open-interest/overview", params)
+        return self.request_endpoint(
+            "open_interest_overview",
+            page=page,
+            limit=limit,
+            key=key,
+            sort=sort,
+            query=query,
+        )
 
     def summary(self, topN: int = 10) -> Dict[str, Any]:
         """Top-line OI aggregates (total USD, top tokens, top exchanges).
@@ -80,7 +81,7 @@ class OpenInterest(API):
         """
         if topN < 1 or topN > 30:
             raise ValueError("topN must be between 1 and 30")
-        return self.query("/api/v1/open-interest/summary", {"top_n": topN})
+        return self.request_endpoint("open_interest_summary", top_n=topN)
 
     def history_aggregated(
         self,
@@ -105,9 +106,9 @@ class OpenInterest(API):
             ``from_`` is named with a trailing underscore because ``from``
             is a Python keyword. The wire-level query param remains ``from``.
         """
-        params: Dict[str, Any] = {"token_id": token_id, "interval": interval}
-        if from_ is not None:
-            params["from"] = from_
-        if to is not None:
-            params["to"] = to
-        return self.query("/api/v1/open-interest/history-aggregated", params)
+        return self.request_endpoint(
+            "open_interest_history_aggregated",
+            token_id=token_id,
+            interval=interval,
+            **{"from": from_, "to": to},
+        )

--- a/datamaxi/datamaxi/premium.py
+++ b/datamaxi/datamaxi/premium.py
@@ -380,5 +380,4 @@ class Premium(API):
         Returns:
             List of supported exchanges
         """
-        url_path = "/api/v1/premium/exchanges"
-        return self.query(url_path)
+        return self.request_endpoint("premium_exchanges")

--- a/datamaxi/naver/__init__.py
+++ b/datamaxi/naver/__init__.py
@@ -29,8 +29,7 @@ class Naver(API):
         Returns:
             List of supported Naver trend token symbols
         """
-        url_path = "/api/v1/naver-trend/symbols"
-        return self.query(url_path)
+        return self.request_endpoint("naver_trend_symbols")
 
     def trend(self, symbol: str, pandas: bool = True) -> Union[List, pd.DataFrame]:
         """Get Naver trend for given token symbol
@@ -47,8 +46,7 @@ class Naver(API):
             Naver trend data as list or pandas DataFrame
         """
         check_required_parameter(symbol, "symbol")
-        params = {"symbol": symbol}
-        res = self.query("/api/v1/naver-trend", params)
+        res = self.request_endpoint("naver_trend", symbol=symbol)
         if pandas:
             return pd.DataFrame(res)
         return res

--- a/datamaxi/telegram/__init__.py
+++ b/datamaxi/telegram/__init__.py
@@ -50,15 +50,14 @@ class Telegram(API):
         if sort not in ["asc", "desc"]:
             raise ValueError("sort must be either asc or desc")
 
-        params = {
-            "page": page,
-            "limit": limit,
-            "category": category,
-            "key": key,
-            "sort": sort,
-        }
-
-        res = self.query("/api/v1/telegram/channels", params)
+        res = self.request_endpoint(
+            "telegram_channels",
+            page=page,
+            limit=limit,
+            category=category,
+            key=key,
+            sort=sort,
+        )
         if res["data"] is None:
             raise ValueError("no data found")
 
@@ -107,16 +106,15 @@ class Telegram(API):
         if sort not in ["asc", "desc"]:
             raise ValueError("sort must be either asc or desc")
 
-        params = {
-            "channel": channel_name,
-            "page": page,
-            "limit": limit,
-            "key": key,
-            "sort": sort,
-            "category": category,
-        }
-
-        res = self.query("/api/v1/telegram/messages", params)
+        res = self.request_endpoint(
+            "telegram_messages",
+            channel=channel_name,
+            page=page,
+            limit=limit,
+            key=key,
+            sort=sort,
+            category=category,
+        )
         if res["data"] is None:
             raise ValueError("no data found")
 


### PR DESCRIPTION
Closes #114

Converts remaining client methods off hardcoded `/api/v…` paths onto `self.request_endpoint("<op_id>", **wire_params)`, single-sourcing path/method/path-query split/defaults from the generated `_endpoints.py`.

## Validation policy (settled)
Each class keeps its own semantic + required checks unchanged (`check_required_parameter(s)`, `market ∈ [spot,futures]`, `sort ∈ [asc,desc]`, currency/type enums, "no data found", DataFrame shaping). `request_endpoint` only owns path/method/split/defaults + a spec-driven required backstop. No error messages or behavior changed; existing tests pass unmodified.

## Converted (fully)
- forex, naver, telegram
- cex_fee, cex_ticker, cex_wallet_status
- cex_announcement
- liquidation (all), open_interest (all)
- funding_rate: history, exchanges, symbols
- cex_symbol: metadata, tags, oi, oi_stats, liquidation
- premium: exchanges

## Left on hardcoded paths — registry/openapi.yaml gaps (would break pinned wire contracts)
- `funding_rate.latest` — registry `funding_rate_latest` lacks `sort`+`limit` (class supports them).
- `cex_token.updates` — registry `cex_token_updates` lacks `sort` (test pins `sort=desc` on wire).
- `cex_symbol.cautions` / `delistings` — registry lacks `base` (class sends it).
- `cex_symbol.volume` — registry `cex_symbol_volume` lacks `exchange` (test pins `exchange` on wire).
- `premium.__call__` — registry `premium` uses snake_case wire keys (`source_exchange`) but class/test pin camelCase (`sourceExchange`), and registry lacks ~40 min/max/funding filter params the class sends.

These need upstream datamaxi-codegen / openapi.yaml fixes before conversion; filed as follow-ups.

## Test plan
- `pytest -m "not integration"`: 113 passed, 11 skipped, 116 deselected.
- `black --check` + `flake8` on `datamaxi/` + `tests/`: clean.
- grep for `/api/v` in `datamaxi/**.py` (excluding `_endpoints.py` + doc-link comments/URLs): only the 5 registry-gap methods above remain.
