### PR TITLE
Convert 4 client methods onto request_endpoint (drop dead params)

### DIFF
--- a/datamaxi/datamaxi/cex_symbol.py
+++ b/datamaxi/datamaxi/cex_symbol.py
@@ -34,43 +34,26 @@ class CexSymbol(API):
         """
         return self.request_endpoint("cex_symbol_tags", exchange=exchange, base=base)
 
-    def cautions(
-        self, exchange: Optional[str] = None, base: Optional[str] = None
-    ) -> Dict[str, Any]:
+    def cautions(self, exchange: Optional[str] = None) -> Dict[str, Any]:
         """Active caution / investment-warning flags per symbol.
 
         `GET /api/v1/cex/symbol/cautions`
         """
-        params: Dict[str, Any] = {}
-        if exchange is not None:
-            params["exchange"] = exchange
-        if base is not None:
-            params["base"] = base
-        return self.query("/api/v1/cex/symbol/cautions", params)
+        return self.request_endpoint("cex_symbol_cautions", exchange=exchange)
 
-    def delistings(
-        self, exchange: Optional[str] = None, base: Optional[str] = None
-    ) -> Dict[str, Any]:
+    def delistings(self, exchange: Optional[str] = None) -> Dict[str, Any]:
         """Scheduled delistings with timestamps.
 
         `GET /api/v1/cex/symbol/delistings`
         """
-        params: Dict[str, Any] = {}
-        if exchange is not None:
-            params["exchange"] = exchange
-        if base is not None:
-            params["base"] = base
-        return self.query("/api/v1/cex/symbol/delistings", params)
+        return self.request_endpoint("cex_symbol_delistings", exchange=exchange)
 
-    def volume(self, base: str, exchange: Optional[str] = None) -> Dict[str, Any]:
+    def volume(self, base: str) -> Dict[str, Any]:
         """Per-exchange 24h volume for a single base asset.
 
         `GET /api/v1/cex/symbol/volume`
         """
-        params: Dict[str, Any] = {"base": base}
-        if exchange is not None:
-            params["exchange"] = exchange
-        return self.query("/api/v1/cex/symbol/volume", params)
+        return self.request_endpoint("cex_symbol_volume", base=base)
 
     def oi(self, base: str, exchange: Optional[str] = None) -> Dict[str, Any]:
         """Per-exchange Open Interest for a single base asset.

--- a/datamaxi/datamaxi/cex_token.py
+++ b/datamaxi/datamaxi/cex_token.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Optional, Tuple, Callable
 from datamaxi.api import API
-from datamaxi.lib.constants import DESC, ASC
 
 
 class CexToken(API):
@@ -20,7 +19,6 @@ class CexToken(API):
         page: int = 1,
         limit: int = 1000,
         type: Optional[str] = None,
-        sort: str = DESC,
     ) -> Tuple[Dict[str, Any], Callable]:
         """Get token update data
 
@@ -31,7 +29,6 @@ class CexToken(API):
         Args:
             page (int): Page number
             limit (int): Limit of data
-            sort (str): Sort order
             type (str): Update type
 
         Returns:
@@ -43,20 +40,12 @@ class CexToken(API):
         if limit < 1:
             raise ValueError("limit must be greater than 0")
 
-        if sort not in [ASC, DESC]:
-            raise ValueError("sort must be either asc or desc")
-
         if type is not None and type not in ["listed", "delisted"]:
             raise ValueError("type must be either listed or delisted when set")
 
-        params = {
-            "page": page,
-            "limit": limit,
-            "type": type,
-            "sort": sort,
-        }
-
-        res = self.query("/api/v1/cex/token/updates", params)
+        res = self.request_endpoint(
+            "cex_token_updates", page=page, limit=limit, type=type
+        )
         if res["data"] is None:
             raise ValueError("no data found")
 
@@ -65,7 +54,6 @@ class CexToken(API):
                 type=type,
                 page=page + 1,
                 limit=limit,
-                sort=sort,
             )
 
         return res, next_request

--- a/datamaxi/datamaxi/funding_rate.py
+++ b/datamaxi/datamaxi/funding_rate.py
@@ -104,8 +104,6 @@ class FundingRate(API):
         self,
         exchange: str = None,
         symbol: str = None,
-        sort: str = None,
-        limit: int = None,
         pandas: bool = True,
     ) -> Union[Dict, pd.DataFrame]:
         """Fetch latest funding rate data
@@ -117,28 +115,14 @@ class FundingRate(API):
         Args:
             exchange (str): exchange name
             symbol (str): Symbol name
-            sort (str): Sort data by `asc` or `desc`
-            limit (int): Limit number of data to return
             pandas (bool): Return data as pandas DataFrame
 
         Returns:
             Latest funding rate data in pandas DataFrame or dict response
         """
-        params = {}
-
-        if exchange is not None:
-            params["exchange"] = exchange
-
-        if symbol is not None:
-            params["symbol"] = symbol
-
-        if sort is not None:
-            params["sort"] = sort
-
-        if limit is not None:
-            params["limit"] = limit
-
-        res = self.query("/api/v1/funding-rate/latest", params)
+        res = self.request_endpoint(
+            "funding_rate_latest", exchange=exchange, symbol=symbol
+        )
 
         if pandas:
             df = pd.DataFrame([res])

--- a/tests/test_cex_symbol.py
+++ b/tests/test_cex_symbol.py
@@ -49,7 +49,7 @@ def test_tags_returns_dict():
 
 @mock_http_response(responses.GET, "/api/v1/cex/symbol/cautions", {"BTC": []})
 def test_cautions_returns_dict():
-    assert _client().cautions(base="BTC") == {"BTC": []}
+    assert _client().cautions(exchange="binance") == {"BTC": []}
 
 
 @mock_http_response(responses.GET, "/api/v1/cex/symbol/delistings", {"BTC": []})
@@ -65,10 +65,9 @@ def test_volume_sends_base_param():
         json={"BTC": {"binance": "100"}},
         status=200,
     )
-    res = _client().volume(base="BTC", exchange="binance")
+    res = _client().volume(base="BTC")
     qs = _qs(responses.calls[0])
     assert qs["base"] == ["BTC"]
-    assert qs["exchange"] == ["binance"]
     assert res == {"BTC": {"binance": "100"}}
 
 

--- a/tests/test_cex_token.py
+++ b/tests/test_cex_token.py
@@ -42,7 +42,6 @@ def test_token_updates_sends_query_params():
     assert qs["page"] == ["3"]
     assert qs["limit"] == ["10"]
     assert qs["type"] == ["listed"]
-    assert qs["sort"] == ["desc"]
 
 
 def test_token_updates_invalid_type_raises_value_error():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -428,18 +428,6 @@ class TestCexToken:
         assert isinstance(result, dict)
         assert "data" in result
 
-    def test_updates_sort_asc(self, datamaxi):
-        """Test token updates with sort=asc."""
-        result, _ = datamaxi.cex.token.updates(sort="asc", limit=10)
-        assert isinstance(result, dict)
-        assert "data" in result
-
-    def test_updates_sort_desc(self, datamaxi):
-        """Test token updates with sort=desc."""
-        result, _ = datamaxi.cex.token.updates(sort="desc", limit=10)
-        assert isinstance(result, dict)
-        assert "data" in result
-
     def test_updates_invalid_type(self, datamaxi):
         """Test that invalid type raises ValueError."""
         with pytest.raises(
@@ -574,26 +562,6 @@ class TestFundingRate:
         )
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 1
-
-    @_FLAKY_PROD_DATA_XFAIL
-    def test_latest_with_sort(self, datamaxi):
-        """Test latest funding rate with sort parameter."""
-        result = datamaxi.funding_rate.latest(
-            exchange="binance",
-            symbol="BTC-USDT",
-            sort="asc",
-        )
-        assert isinstance(result, pd.DataFrame)
-
-    @_FLAKY_PROD_DATA_XFAIL
-    def test_latest_with_limit(self, datamaxi):
-        """Test latest funding rate with limit parameter."""
-        result = datamaxi.funding_rate.latest(
-            exchange="binance",
-            symbol="BTC-USDT",
-            limit=5,
-        )
-        assert isinstance(result, pd.DataFrame)
 
     @_FLAKY_PROD_DATA_XFAIL
     def test_latest_pandas_false(self, datamaxi):


### PR DESCRIPTION
Closes #116

## Summary
Converts 4 client methods off hardcoded `self.query("/api/v1/...")` calls onto `self.request_endpoint(op_id, **wire_params)`, using snake_case wire params from the codegen'd `datamaxi/_endpoints.py` registry (the live backend contract). Dead kwargs the backend silently ignores are removed from the Python signatures (pre-1.0 cleanup — passing them now raises `TypeError`). Over-specified mocked tests updated to the real contract.

**Premium was pulled from this PR** — the registry is incomplete for `premium` (missing ~35 filter params, incl. known-working `token_include`/`token_exclude`; keeps `min_sv` but not `max_sv`), so routing it through `request_endpoint` would silently drop working filters. Tracked separately in #119 (fix camelCase wire bug + expand registry upstream, then convert).

Per method:
- **funding_rate.latest** — dropped `sort`, `limit` (not in registry). Now `request_endpoint("funding_rate_latest", exchange=, symbol=)`.
- **cex_token.updates** — dropped `sort` + its ASC/DESC validation; removed now-unused DESC/ASC import. Now `request_endpoint("cex_token_updates", page=, limit=, type=)`. Kept (response, next_request) tuple.
- **cex_symbol.volume** — dropped `exchange`. Signature now `volume(base)`.
- **cex_symbol.cautions / delistings** — dropped `base`. Kept `exchange`.

Note: the registry defines additional filters not yet exposed (cex_symbol delistings `market/from_ms/to_ms/include_past/limit/page`, cautions `market/min_level/active_only/limit/page`, cex_symbol_volume `market`); left out to keep scope to the issue. Can be added later.

## Test plan
- Updated mocked tests to real contract: `test_token_updates_sends_query_params` (removed `sort` assertion), `test_volume_sends_base_param` (dropped `exchange`), `test_cautions_returns_dict` (base → exchange).
- Removed integration cases for removed kwargs: `test_updates_sort_asc/desc`, `test_latest_with_sort`, `test_latest_with_limit` (would `TypeError` under `-m integration`).
- Offline suite green: `python -m pytest -m "not integration"` → 113 passed, 11 skipped, 116 deselected.
- Integration file collects clean; black + flake8 clean on touched files. `grep -rn "/api/v" datamaxi/datamaxi/*.py` clean except doc-link comments; no `self.query(` remains in the 4 methods.
