### PR TITLE
fix(premium): snake_case source/target exchange+quote wire keys

### DIFF
--- a/datamaxi/datamaxi/premium.py
+++ b/datamaxi/datamaxi/premium.py
@@ -162,19 +162,19 @@ class Premium(API):
         params = {}
 
         if source_exchange is not None:
-            params["sourceExchange"] = source_exchange
+            params["source_exchange"] = source_exchange
 
         if target_exchange is not None:
-            params["targetExchange"] = target_exchange
+            params["target_exchange"] = target_exchange
 
         if asset is not None:
             params["asset"] = asset
 
         if source_quote is not None:
-            params["sourceQuote"] = source_quote
+            params["source_quote"] = source_quote
 
         if target_quote is not None:
-            params["targetQuote"] = target_quote
+            params["target_quote"] = target_quote
 
         if sort is not None:
             params["sort"] = sort

--- a/tests/test_premium.py
+++ b/tests/test_premium.py
@@ -55,10 +55,16 @@ def test_premium_call_param_name_translation():
         json=_RESPONSE,
         status=200,
     )
-    _client()(source_exchange="binance", conversion_base="USDT", page=2)
+    _client()(
+        source_exchange="binance",
+        target_quote="USDT",
+        conversion_base="USDT",
+        page=2,
+    )
     qs = _qs(responses.calls[0])
-    # camelCase wire keys for exchange params, snake_case for conversion_base
-    assert qs["sourceExchange"] == ["binance"]
+    # snake_case wire keys for all params (backend expects snake_case)
+    assert qs["source_exchange"] == ["binance"]
+    assert qs["target_quote"] == ["USDT"]
     assert qs["conversion_base"] == ["USDT"]
     assert qs["page"] == ["2"]
 


### PR DESCRIPTION
Closes #119 (partial: Step 1 only)

## Summary
`premium.__call__` hand-translated 4 snake_case Python kwargs into camelCase wire keys, which the snake_case backend silently ignored — so source/target exchange + quote filtering was broken against the live API. Fixed the 4 wire keys to snake_case:

- `sourceExchange` -> `source_exchange`
- `targetExchange` -> `target_exchange`
- `sourceQuote` -> `source_quote`
- `targetQuote` -> `target_quote`

Public Python kwargs were already snake_case; only the wire keys were wrong. All other params already used snake_case keys and are untouched. `self.query("/api/v1/premium", params)` left in place.

## Deferred (NOT in this PR)
Step 2 — expanding the codegen registry (`datamaxi/_endpoints.py`, op `premium`) in the upstream `../datamaxi-backend` OpenAPI spec, live param-by-param verification, converting `premium.__call__` onto `request_endpoint`, and adding `tests/test_integration.py` premium cases — is UPSTREAM-BLOCKED and intentionally deferred. The registry is incomplete for premium, so routing through `request_endpoint` (which rejects any param absent from the registry) would silently drop working filters.

Note: `Closes #119` will auto-close this issue on merge. A follow-up issue should track deferred Step 2.

## Test plan
- `python -m pytest tests/test_premium.py -q -m "not integration"` -> 6 passed
- `python -m pytest -q -m "not integration"` -> 113 passed, 11 skipped, 112 deselected
- `flake8 datamaxi/datamaxi/premium.py tests/test_premium.py` -> clean
- `black --check` on both files -> unchanged

Updated `test_premium_call_param_name_translation` to assert snake_case wire keys (`source_exchange`, `target_quote`) and fixed the misleading comment.
