### PR TITLE
Convert premium.__call__ onto request_endpoint; drop data-api-dead filters (#121)

### DIFF
--- a/datamaxi/datamaxi/premium.py
+++ b/datamaxi/datamaxi/premium.py
@@ -31,54 +31,12 @@ class Premium(API):
         limit: int = 100,
         currency: str = None,
         conversion_base: str = None,
-        min_pd: str = None,
-        max_pd: str = None,
-        min_pdp: str = None,
-        max_pdp: str = None,
-        min_pdp24h: str = None,
-        max_pdp24h: str = None,
-        min_pdp4h: str = None,
-        max_pdp4h: str = None,
-        min_pdp1h: str = None,
-        max_pdp1h: str = None,
-        min_pdp30m: str = None,
-        max_pdp30m: str = None,
-        min_pdp15m: str = None,
-        max_pdp15m: str = None,
-        min_pdp5m: str = None,
-        max_pdp5m: str = None,
-        min_dsp: str = None,
-        max_dsp: str = None,
-        min_dtp: str = None,
-        max_dtp: str = None,
-        min_spdp24h: str = None,
-        max_spdp24h: str = None,
-        min_spdp4h: str = None,
-        max_spdp4h: str = None,
-        min_spdp1h: str = None,
-        max_spdp1h: str = None,
-        min_spdp30m: str = None,
-        max_spdp30m: str = None,
-        min_spdp15m: str = None,
-        max_spdp15m: str = None,
-        min_spdp5m: str = None,
-        max_spdp5m: str = None,
         min_sv: str = None,
-        max_sv: str = None,
         min_tv: str = None,
-        max_tv: str = None,
-        min_net_funding_rate: str = None,
-        max_net_funding_rate: str = None,
-        min_source_funding_rate: str = None,
-        max_source_funding_rate: str = None,
-        min_target_funding_rate: str = None,
-        max_target_funding_rate: str = None,
         source_market: str = None,
         target_market: str = None,
         only_transferable: bool = False,
         network: str = None,
-        source_funding_rate_interval: str = None,
-        target_funding_rate_interval: str = None,
         premium_type: str = None,
         token_include: str = None,
         token_exclude: str = None,
@@ -101,55 +59,12 @@ class Premium(API):
             limit (int): Page size
             currency (str): Currency applied to cross-exchange price differences
             conversion_base (str): conversion base for price difference calculation
-
-            min_pd (str): Return results with price difference in USD above min_pd
-            max_pd (str): Return results with price difference in USD below max_pd
-            min_pdp (str): Return results with price difference percentage above min_pdp
-            max_pdp (str): Return results with price difference percentage below max_pdp
-            min_pdp24h (str): Return results with price difference percentage from 24h ago above min_pdp24h
-            max_pdp24h (str): Return results with price difference percentage from 24h ago below max_pdp24h
-            min_pdp4h (str): Return results with price difference percentage from 4h ago above min_pdp4h
-            max_pdp4h (str): Return results with price difference percentage from 4h ago below max_pdp4h
-            min_pdp1h (str): Return results with price difference percentage from 1h ago above min_pdp1h
-            max_pdp1h (str): Return results with price difference percentage from 1h ago below max_pdp1h
-            min_pdp30m (str): Return results with price difference percentage from 30m ago above min_pdp30m
-            max_pdp30m (str): Return results with price difference percentage from 30m ago below max_pdp30m
-            min_pdp15m (str): Return results with price difference percentage from 15m ago above min_pdp15m
-            max_pdp15m (str): Return results with price difference percentage from 15m ago below max_pdp15m
-            min_pdp5m (str): Return results with price difference percentage from 5m ago above min_pdp5m
-            max_pdp5m (str): Return results with price difference percentage from 5m ago below max_pdp5m
-            min_dsp (str): Return results with price in fiat on source exchange above min_dsp
-            max_dsp (str): Return results with price in fiat on source exchange below max_dsp
-            min_dtp (str): Return results with price in fiat on target exchange above min_dtp
-            max_dtp (str): Return results with price in fiat on target exchange below max_dtp
-            min_spdp24h (str): Return results with price difference percentage (between now and 24h ago on source exchange) above min_spdp24h
-            max_spdp24h (str): Return results with price difference percentage (between now and 24h ago on source exchange) below max_spdp24h
-            min_spdp4h (str): Return results with price difference percentage (between now and 4h ago on source exchange) above min_spdp4h
-            max_spdp4h (str): Return results with price difference percentage (between now and 4h ago on source exchange) below max_spdp4h
-            min_spdp1h (str): Return results with price difference percentage (between now and 1h ago on source exchange) above min_spdp1h
-            max_spdp1h (str): Return results with price difference percentage (between now and 1h ago on source exchange) below max_spdp1h
-            min_spdp30m (str): Return results with price difference percentage (between now and 30m ago on source exchange) above min_spdp30m
-            max_spdp30m (str): Return results with price difference percentage (between now and 30m ago on source exchange) below max_spdp30m
-            min_spdp15m (str): Return results with price difference percentage (between now and 15m ago on source exchange) above min_spdp15m
-            max_spdp15m (str): Return results with price difference percentage (between now and 15m ago on source exchange) below max_spdp15m
-            min_spdp5m (str): Return results with price difference percentage (between now and 5m ago on source exchange) above min_spdp5m
-            max_spdp5m (str): Return results with price difference percentage (between now and 5m ago on source exchange) below max_spdp5m
             min_sv (str): Return results with 24h volume in fiat on source exchange above min_sv
-            max_sv (str): Return results with 24h volume in fiat on source exchange below max_sv
             min_tv (str): Return results with 24h volume in fiat on target exchange above min_tv
-            max_tv (str): Return results with 24h volume in fiat on target exchange below max_tv
-            min_net_funding_rate (str): Return results with net funding rate above min_net_funding_rate
-            max_net_funding_rate (str): Return results with net funding rate below max_net_funding_rate
-            min_source_funding_rate (str): Return results with source funding rate above min_source_funding_rate
-            max_source_funding_rate (str): Return results with source funding rate below max_source_funding_rate
-            min_target_funding_rate (str): Return results with target funding rate above min_target_funding_rate
-            max_target_funding_rate (str): Return results with target funding rate below max_target_funding_rate
             source_market (str): Return results matching source market
             target_market (str): Return results matching target market
             only_transferable (bool): Return only transferable if set true
             network (str): Return results containing only specified network
-            source_funding_rate_interval (str): Return results with min source funding rate interval
-            target_funding_rate_interval (str): Return results with min target funding rate interval
             premium_type (str): Return based on matching premium_type
             token_include (str): Return results containing only specified token
             token_exclude (str): Return results not containing specified token
@@ -194,131 +109,11 @@ class Premium(API):
         if conversion_base is not None:
             params["conversion_base"] = conversion_base
 
-        if min_pd is not None:
-            params["min_pd"] = min_pd
-
-        if max_pd is not None:
-            params["max_pd"] = max_pd
-
-        if min_pdp is not None:
-            params["min_pdp"] = min_pdp
-
-        if max_pdp is not None:
-            params["max_pdp"] = max_pdp
-
-        if min_pdp24h is not None:
-            params["min_pdp24h"] = min_pdp24h
-
-        if max_pdp24h is not None:
-            params["max_pdp24h"] = max_pdp24h
-
-        if min_pdp4h is not None:
-            params["min_pdp4h"] = min_pdp4h
-
-        if max_pdp4h is not None:
-            params["max_pdp4h"] = max_pdp4h
-
-        if min_pdp1h is not None:
-            params["min_pdp1h"] = min_pdp1h
-
-        if max_pdp1h is not None:
-            params["max_pdp1h"] = max_pdp1h
-
-        if min_pdp30m is not None:
-            params["min_pdp30m"] = min_pdp30m
-
-        if max_pdp30m is not None:
-            params["max_pdp30m"] = max_pdp30m
-
-        if min_pdp15m is not None:
-            params["min_pdp15m"] = min_pdp15m
-
-        if max_pdp15m is not None:
-            params["max_pdp15m"] = max_pdp15m
-
-        if min_pdp5m is not None:
-            params["min_pdp5m"] = min_pdp5m
-
-        if max_pdp5m is not None:
-            params["max_pdp5m"] = max_pdp5m
-
-        if min_dsp is not None:
-            params["min_dsp"] = min_dsp
-
-        if max_dsp is not None:
-            params["max_dsp"] = max_dsp
-
-        if min_dtp is not None:
-            params["min_dtp"] = min_dtp
-
-        if max_dtp is not None:
-            params["max_dtp"] = max_dtp
-
-        if min_spdp24h is not None:
-            params["min_spdp24h"] = min_spdp24h
-
-        if max_spdp24h is not None:
-            params["max_spdp24h"] = max_spdp24h
-
-        if min_spdp4h is not None:
-            params["min_spdp4h"] = min_spdp4h
-
-        if max_spdp4h is not None:
-            params["max_spdp4h"] = max_spdp4h
-
-        if min_spdp1h is not None:
-            params["min_spdp1h"] = min_spdp1h
-
-        if max_spdp1h is not None:
-            params["max_spdp1h"] = max_spdp1h
-
-        if min_spdp30m is not None:
-            params["min_spdp30m"] = min_spdp30m
-
-        if max_spdp30m is not None:
-            params["max_spdp30m"] = max_spdp30m
-
-        if min_spdp15m is not None:
-            params["min_spdp15m"] = min_spdp15m
-
-        if max_spdp15m is not None:
-            params["max_spdp15m"] = max_spdp15m
-
-        if min_spdp5m is not None:
-            params["min_spdp5m"] = min_spdp5m
-
-        if max_spdp5m is not None:
-            params["max_spdp5m"] = max_spdp5m
-
         if min_sv is not None:
             params["min_sv"] = min_sv
 
-        if max_sv is not None:
-            params["max_sv"] = max_sv
-
         if min_tv is not None:
             params["min_tv"] = min_tv
-
-        if max_tv is not None:
-            params["max_tv"] = max_tv
-
-        if min_net_funding_rate is not None:
-            params["min_net_funding_rate"] = min_net_funding_rate
-
-        if max_net_funding_rate is not None:
-            params["max_net_funding_rate"] = max_net_funding_rate
-
-        if min_source_funding_rate is not None:
-            params["min_source_funding_rate"] = min_source_funding_rate
-
-        if max_source_funding_rate is not None:
-            params["max_source_funding_rate"] = max_source_funding_rate
-
-        if min_target_funding_rate is not None:
-            params["min_target_funding_rate"] = min_target_funding_rate
-
-        if max_target_funding_rate is not None:
-            params["max_target_funding_rate"] = max_target_funding_rate
 
         if source_market is not None:
             params["source_market"] = source_market
@@ -332,12 +127,6 @@ class Premium(API):
         if network is not None:
             params["network"] = network
 
-        if source_funding_rate_interval is not None:
-            params["source_funding_rate_interval"] = source_funding_rate_interval
-
-        if target_funding_rate_interval is not None:
-            params["target_funding_rate_interval"] = target_funding_rate_interval
-
         if premium_type is not None:
             params["premium_type"] = premium_type
 
@@ -347,7 +136,7 @@ class Premium(API):
         if token_exclude is not None:
             params["token_exclude"] = token_exclude
 
-        res = self.query("/api/v1/premium", params)
+        res = self.request_endpoint("premium", **params)
         if res["data"] is None or len(res["data"]) == 0:
             raise ValueError("no data found")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -649,34 +649,9 @@ class TestPremium:
         result = datamaxi.premium(sort="desc", key="pdp", limit=10)
         assert isinstance(result, pd.DataFrame)
 
-    def test_premium_min_pdp(self, datamaxi):
-        """Test premium data with min_pdp filter."""
-        result = datamaxi.premium(min_pdp="1", limit=10)
-        assert isinstance(result, pd.DataFrame)
-
-    def test_premium_max_pdp(self, datamaxi):
-        """Test premium data with max_pdp filter."""
-        result = datamaxi.premium(max_pdp="10", limit=10)
-        assert isinstance(result, pd.DataFrame)
-
-    def test_premium_min_max_pdp(self, datamaxi):
-        """Test premium data with both min and max pdp."""
-        result = datamaxi.premium(min_pdp="1", max_pdp="10", limit=50)
-        assert isinstance(result, pd.DataFrame)
-
-    def test_premium_pdp24h_filters(self, datamaxi):
-        """Test premium data with pdp24h filters."""
-        result = datamaxi.premium(min_pdp24h="-5", max_pdp24h="5", limit=10)
-        assert isinstance(result, pd.DataFrame)
-
     def test_premium_volume_filters(self, datamaxi):
         """Test premium data with volume filters."""
         result = datamaxi.premium(min_sv="100000", limit=10)
-        assert isinstance(result, pd.DataFrame)
-
-    def test_premium_funding_rate_filters(self, datamaxi):
-        """Test premium data with funding rate filters."""
-        result = datamaxi.premium(min_net_funding_rate="-0.01", limit=10)
         assert isinstance(result, pd.DataFrame)
 
     def test_premium_only_transferable(self, datamaxi):


### PR DESCRIPTION
Closes #121

Follow-up to #119 / PR #120 (Step 1, camelCase→snake_case wire fix). This is the deferred Step 2.

## Correction to the issue premise
The issue proposed expanding the codegen registry upstream. That was **investigated and dropped**: verified against datamaxi-backend `main` that the data-api `/api/v1/premium` Go handler reads **exactly the 21 query params already in `datamaxi/_endpoints.py` op `premium`**. The ~34 extra kwargs `premium.__call__` was sending are **dead** — silently ignored by data-api; they belong to the spec-excluded front-api `/api/v1/front/premium`. So no registry/backend changes.

## Direction A (this PR)
Route `Premium.__call__` through `self.request_endpoint("premium", **params)` instead of the hand-rolled `self.query("/api/v1/premium", params)`, and drop the dead kwargs at the signature level (`request_endpoint` rejects any param absent from the registry).

**Retained kwargs (20 + `pandas`):** source_exchange, target_exchange, asset, source_quote, target_quote, sort, key, page, limit, currency, conversion_base, min_sv, min_tv, source_market, target_market, only_transferable, network, premium_type, token_include, token_exclude.

**Dropped kwargs (dead):** min_pd/max_pd, all min_pdp*/max_pdp* (incl. 24h/4h/1h/30m/15m/5m), min_dsp/max_dsp, min_dtp/max_dtp, all min_spdp*/max_spdp*, max_sv, max_tv, min/max net/source/target funding-rate, source/target funding_rate_interval.

Response handling (empty-data ValueError, DataFrame flatten of `detail` + annualized funding rates, `pandas=False` raw return) unchanged. `exchanges()` untouched.

## Test plan
- `pytest -m "not integration"`: **113 passed, 11 skipped, 107 deselected**.
- Removed 5 integration methods that passed now-dropped kwargs (would raise TypeError): `test_premium_min_pdp`, `test_premium_max_pdp`, `test_premium_min_max_pdp`, `test_premium_pdp24h_filters`, `test_premium_funding_rate_filters`. Other premium integration tests (incl. `test_premium_volume_filters` using min_sv) intact.
- `flake8` + `black --check` clean. `# noqa: C901` kept (complexity 23 > 10).