### PR TITLE
ci: run live keyed test suite on push to main (non-blocking)

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -13,6 +13,10 @@ on:
       - 'LICENSE'
       - '.gitignore'
 
+# Least-privilege token: the job only checks out code.
+permissions:
+  contents: read
+
 jobs:
   live:
     runs-on: ubuntu-latest

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -1,0 +1,44 @@
+name: Live keyed tests
+
+# Runs the FULL suite (integration + smoke) against prod using the
+# DATAMAXI_API_KEY secret. Gated to push on `main` only: a dedicated
+# `on: push: branches: [main]` guarantees fork/branch pushes never trigger
+# this lane, so the secret is never exposed to untrusted refs.
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+
+jobs:
+  live:
+    runs-on: ubuntu-latest
+    # Non-blocking: transient prod-data flakiness (cold pods -> 500 "no data
+    # found", empty-page premium ValueError) must not fail a run. PRs never
+    # trigger this lane (main-only), so the required offline build stays the
+    # gating check.
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+    - name: Install dependencies
+      run: uv pip install --system -r requirements/requirements-test.txt
+    # Full keyed suite: integration + smoke lanes hit prod with the secret key.
+    # DATAMAXI_TIMEOUT bumped past the conftest 30s default to tolerate slow
+    # cold pods.
+    - name: Run live keyed tests
+      env:
+        DATAMAXI_API_KEY: ${{ secrets.DATAMAXI_API_KEY }}
+        DATAMAXI_TIMEOUT: "60"
+      run: python -m pytest tests/ -q


### PR DESCRIPTION
Closes #131

## Summary
Adds a dedicated `live-tests.yml` workflow that runs the FULL suite (integration + smoke lanes) against prod using the `DATAMAXI_API_KEY` secret, on **push to `main` only**. Non-blocking so transient prod-data flakiness never fails a required build.

## Separate workflow vs gated job
Chose a **separate workflow** keyed on `on: push: branches: [main]` rather than an `if: github.ref == ...` gated job in `python-package.yml`. A branch-scoped trigger is the cleanest guarantee the keyed lane never runs on fork/branch pushes, so the secret is never exposed to untrusted refs. It also keeps the required offline matrix build fully untouched.

## Behavior
- Mirrors the offline lane setup (checkout@v4, setup-uv@v6, `uv pip install --system -r requirements/requirements-test.txt`); single Python 3.12 (no matrix needed for the live lane).
- `continue-on-error: true` -> non-blocking. Cold-pod 500s and empty-page premium `ValueError` (per #130) won't fail the run.
- `DATAMAXI_TIMEOUT=60` env to tolerate slow cold prod pods (conftest default is 30s).
- `paths-ignore` mirrors the offline lane (skip docs/md/license/gitignore-only pushes).

## Required manual step
The **`DATAMAXI_API_KEY`** repo secret must be added in repo settings (Secrets and variables -> Actions) for this lane to authenticate. Until then the lane runs keyless: conftest resolves no key, both live lanes `skipif`-skip cleanly, and the non-blocking job stays green. Behavior with the secret absent is acceptable.

## Test plan
- All four workflow YAMLs validated with `yaml.safe_load` (parse OK).
- Offline required lane (`python-package.yml`) unchanged — no edits.
- New lane is main-only + `continue-on-error`, so PRs (this one included) do not trigger it.