### PR TITLE
fix: assign config flags directly in API.__init__ (#5)

### DIFF
--- a/datamaxi/api.py
+++ b/datamaxi/api.py
@@ -39,9 +39,9 @@ class API(object):
         self.api_key = api_key or os.environ.get("DATAMAXI_API_KEY")
         self.base_url = base_url
         self.timeout = timeout
-        self.proxies = None
-        self.show_limit_usage = False
-        self.show_header = False
+        self.proxies = proxies if type(proxies) is dict else None
+        self.show_limit_usage = bool(show_limit_usage)
+        self.show_header = bool(show_header)
 
         self.session = requests.Session()
         self.session.headers.update(
@@ -51,15 +51,6 @@ class API(object):
                 "X-DTMX-APIKEY": str(self.api_key),
             }
         )
-
-        if show_limit_usage is True:
-            self.show_limit_usage = True
-
-        if show_header is True:
-            self.show_header = True
-
-        if type(proxies) is dict:
-            self.proxies = proxies
 
         self._logger = logging.getLogger(__name__)
         return


### PR DESCRIPTION
## Summary
First of 4 small, independent PRs cleaning up the hand-written SDK surface (issues #1–#5 from a structure review). This one fixes the config-ordering smell in `API.__init__`.

`proxies`, `show_limit_usage`, and `show_header` were hardcoded to `None`/`False`, then conditionally overwritten by `if` blocks lower in the constructor. Collapsed to direct assignment from the params.

- `proxies` → kept the `type(proxies) is dict` guard, inline
- `show_limit_usage` / `show_header` → `bool(...)` (was `is True`; now also accepts truthy, which is friendlier)

No behavior change for existing callers passing bools/dicts.

## Tests
- `pytest -m "not integration"`: **134 passed, 11 skipped**
- black + flake8 clean on `datamaxi/api.py`

## Known failures
None.