### PR TITLE
refactor: share one Session across the client tree via composition (#2, #3)

### DIFF
--- a/datamaxi/api.py
+++ b/datamaxi/api.py
@@ -179,3 +179,26 @@ class API(object):
                 error_data,
             )
         raise ServerError(status_code, response.text)
+
+
+class Resource(object):
+    """Base for endpoint/resource clients — *composes* an `API` transport
+    rather than subclassing it.
+
+    Every resource holds a shared `API` (one `requests.Session` /
+    connection pool) instead of each opening its own. A resource either
+    receives an already-built ``api`` (the normal path — `Datamaxi`
+    constructs one and threads it through the whole tree via ``**kwargs``)
+    or builds its own from ``api_key``/``**kwargs`` for direct, standalone
+    instantiation. The thin `request_endpoint`/`query` forwarders keep the
+    call sites in the resource methods unchanged (`self.request_endpoint(...)`).
+    """
+
+    def __init__(self, api_key=None, api=None, **kwargs):
+        self._api = api if api is not None else API(api_key, **kwargs)
+
+    def request_endpoint(self, op_id, **params):
+        return self._api.request_endpoint(op_id, **params)
+
+    def query(self, url_path, payload=None):
+        return self._api.query(url_path, payload=payload)

--- a/datamaxi/datamaxi/__init__.py
+++ b/datamaxi/datamaxi/__init__.py
@@ -1,4 +1,5 @@
 from typing import Any
+from datamaxi.api import API
 from datamaxi.lib.constants import BASE_URL
 from datamaxi.datamaxi.cex import Cex
 from datamaxi.datamaxi.funding_rate import FundingRate
@@ -42,17 +43,22 @@ class Datamaxi:
         if "base_url" not in kwargs:
             kwargs["base_url"] = BASE_URL
 
-        self.cex = Cex(api_key, **kwargs)
-        self.funding_rate = FundingRate(api_key, **kwargs)
-        self.forex = Forex(api_key, **kwargs)
-        self.premium = Premium(api_key, **kwargs)
+        # One shared transport — a single `requests.Session` / connection
+        # pool threaded through every sub-client instead of each opening
+        # its own. Sub-clients receive it via `api=` and forward it down.
+        api = API(api_key, **kwargs)
+
+        self.cex = Cex(api=api)
+        self.funding_rate = FundingRate(api=api)
+        self.forex = Forex(api=api)
+        self.premium = Premium(api=api)
         # Futures-only surfaces. Top-level on the client so callers
         # reach them via `client.liquidation.heatmap(...)` /
         # `client.open_interest.summary(...)` — matches the
         # `/api/v1/{liquidation,open-interest}/*` REST grouping and
         # mirrors the equivalent typed wrappers in the Rust SDK
         # (`datamaxi::generated::{Liquidation, OpenInterest}`).
-        self.liquidation = Liquidation(api_key, **kwargs)
-        self.open_interest = OpenInterest(api_key, **kwargs)
-        self.margin_borrow = MarginBorrow(api_key, **kwargs)
-        self.index_price = IndexPrice(api_key, **kwargs)
+        self.liquidation = Liquidation(api=api)
+        self.open_interest = OpenInterest(api=api)
+        self.margin_borrow = MarginBorrow(api=api)
+        self.index_price = IndexPrice(api=api)

--- a/datamaxi/datamaxi/cex.py
+++ b/datamaxi/datamaxi/cex.py
@@ -1,5 +1,5 @@
 from typing import Any
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.datamaxi.cex_candle import CexCandle
 from datamaxi.datamaxi.cex_ticker import CexTicker
 from datamaxi.datamaxi.cex_fee import CexFee
@@ -9,7 +9,7 @@ from datamaxi.datamaxi.cex_token import CexToken
 from datamaxi.datamaxi.cex_symbol import CexSymbol
 
 
-class Cex(API):
+class Cex(Resource):
     """Client to fetch CEX data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/cex_announcement.py
+++ b/datamaxi/datamaxi/cex_announcement.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, Optional, Tuple, Callable
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.constants import ASC, DESC, SortOrder
 
 
-class CexAnnouncement(API):
+class CexAnnouncement(Resource):
     """Client to fetch announcement data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/cex_candle.py
+++ b/datamaxi/datamaxi/cex_candle.py
@@ -1,13 +1,13 @@
 from typing import Any, List, Dict, Union, Optional
 import pandas as pd
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameter
 from datamaxi.lib.utils import check_required_parameters
 from datamaxi.datamaxi.utils import convert_data_to_data_frame
 from datamaxi.lib.constants import SPOT, FUTURES, INTERVAL_1D, USD, Market, Interval
 
 
-class CexCandle(API):
+class CexCandle(Resource):
     """Client to fetch CEX candle data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/cex_fee.py
+++ b/datamaxi/datamaxi/cex_fee.py
@@ -1,9 +1,9 @@
 from typing import Any, List, Dict
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameter
 
 
-class CexFee(API):
+class CexFee(Resource):
     """Client to fetch CEX trading fee data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/cex_symbol.py
+++ b/datamaxi/datamaxi/cex_symbol.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict, Optional
-from datamaxi.api import API
+from datamaxi.api import Resource
 
 
-class CexSymbol(API):
+class CexSymbol(Resource):
     """Client to fetch per-base / per-symbol CEX metadata + aggregates."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/cex_ticker.py
+++ b/datamaxi/datamaxi/cex_ticker.py
@@ -1,11 +1,11 @@
 from typing import Any, List, Dict, Union
 import pandas as pd
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameters
 from datamaxi.lib.constants import SPOT, FUTURES, Market
 
 
-class CexTicker(API):
+class CexTicker(Resource):
     """Client to fetch ticker data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/cex_token.py
+++ b/datamaxi/datamaxi/cex_token.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict, Optional, Tuple, Callable
-from datamaxi.api import API
+from datamaxi.api import Resource
 
 
-class CexToken(API):
+class CexToken(Resource):
     """Client to fetch token update data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/cex_wallet_status.py
+++ b/datamaxi/datamaxi/cex_wallet_status.py
@@ -1,11 +1,11 @@
 from typing import Any, List, Dict, Union
 import pandas as pd
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameters
 from datamaxi.lib.utils import check_required_parameter
 
 
-class CexWalletStatus(API):
+class CexWalletStatus(Resource):
     """Client to fetch transfer status data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/forex.py
+++ b/datamaxi/datamaxi/forex.py
@@ -1,10 +1,10 @@
 from typing import Any, List, Dict, Union
 import pandas as pd
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameter
 
 
-class Forex(API):
+class Forex(Resource):
     """Client to fetch forex data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/funding_rate.py
+++ b/datamaxi/datamaxi/funding_rate.py
@@ -1,13 +1,13 @@
 from typing import Any, Callable, Tuple, List, Dict, Union
 import pandas as pd
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameter
 from datamaxi.lib.utils import check_required_parameters
 from datamaxi.datamaxi.utils import convert_data_to_data_frame
 from datamaxi.lib.constants import ASC, DESC, SortOrder
 
 
-class FundingRate(API):
+class FundingRate(Resource):
     """Client to fetch funding rate data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/index_price.py
+++ b/datamaxi/datamaxi/index_price.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, Optional
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameter
 from datamaxi.lib.constants import Interval
 
 
-class IndexPrice(API):
+class IndexPrice(Resource):
     """Client to fetch historical index price data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/liquidation.py
+++ b/datamaxi/datamaxi/liquidation.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, Optional
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.constants import Interval
 
 
-class Liquidation(API):
+class Liquidation(Resource):
     """Client to fetch CEX futures liquidation data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/margin_borrow.py
+++ b/datamaxi/datamaxi/margin_borrow.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameter
 
 
-class MarginBorrow(API):
+class MarginBorrow(Resource):
     """Client to fetch margin borrow data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/open_interest.py
+++ b/datamaxi/datamaxi/open_interest.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, Optional
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.constants import Interval, SortOrder
 
 
-class OpenInterest(API):
+class OpenInterest(Resource):
     """Client to fetch CEX futures Open Interest data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/datamaxi/premium.py
+++ b/datamaxi/datamaxi/premium.py
@@ -1,10 +1,10 @@
 from typing import Any, List, Union, Optional
 import pandas as pd
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.constants import Market, SortOrder
 
 
-class Premium(API):
+class Premium(Resource):
     """Client to fetch premium data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/naver/__init__.py
+++ b/datamaxi/naver/__init__.py
@@ -1,11 +1,11 @@
 from typing import Any, List, Union
 import pandas as pd
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameter
 from datamaxi.lib.constants import BASE_URL
 
 
-class Naver(API):
+class Naver(Resource):
     """Client to fetch Naver trend data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):

--- a/datamaxi/telegram/__init__.py
+++ b/datamaxi/telegram/__init__.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, Optional, Tuple, Callable
-from datamaxi.api import API
+from datamaxi.api import Resource
 from datamaxi.lib.constants import BASE_URL, SortOrder
 
 
-class Telegram(API):
+class Telegram(Resource):
     """Client to fetch Telegram data from DataMaxi+ API."""
 
     def __init__(self, api_key=None, **kwargs: Any):


### PR DESCRIPTION
## Summary
PR 3 of 4 from the SDK-structure review — fixes issues #2 (per-resource `Session`s) and #3 (is-a instead of has-a) together, since they share one root cause.

**Before:** every resource subclassed `API`, so each `super().__init__` opened its own `requests.Session`. A single `Datamaxi` client created ~15 sessions/connection pools; grouping classes like `Cex` *were* an `API` (inheriting `send_request`, `_handle_exception`, `session`, …) they never used as one.

**After:** a new `Resource` base (in `api.py`) **composes** an `API` — holds a shared instance and forwards `request_endpoint`/`query`. `Datamaxi` builds **one** `API` and threads it through the whole tree via `api=`; the value rides through `**kwargs`, so resource method bodies are untouched. Standalone instantiation (`CexTicker(api_key=..., base_url=...)`) still builds its own transport.

Net: **one `Session` / connection pool** for the entire client, and `client.cex` is now a namespace (`Resource`), not an `API`.

## Verification
- Smoke test on a live `Datamaxi("k")`: **1** distinct `_api` object and **1** distinct `Session` across `cex`, `cex.candle`, `cex.ticker`, `cex.symbol`, `premium`, `funding_rate`, `liquidation`, `index_price`; `isinstance(cex, Resource)` True, `isinstance(cex, API)` False; standalone `CexTicker` keeps its own transport.
- `pytest -m "not integration"`: **134 passed, 11 skipped**
- black + flake8 clean across `datamaxi/`

## Compatibility
No public surface change — `client.cex.candle(...)`, direct resource instantiation, and the mocked/live test lanes all behave as before. conftest's `API.send_request` monkeypatch still applies (delegation routes through the shared `API`). `_endpoints.py` (codegen'd upstream) untouched.

## Known failures
None.

## Note
The `Resource` methods forward only `request_endpoint`/`query` — the two `API` members any resource actually calls on `self` (verified by grep; no resource touches `self.session`/`self.base_url`/`send_request` directly).