### PR TITLE
feat: __repr__ + lazy pandas import (#143)

### DIFF
--- a/datamaxi/api.py
+++ b/datamaxi/api.py
@@ -113,6 +113,11 @@ class API(object):
         self.session.mount("https://", adapter)
         self.session.mount("http://", adapter)
 
+    def __repr__(self):
+        return "{}(base_url={!r}, has_key={})".format(
+            type(self).__name__, self.base_url, bool(self.api_key)
+        )
+
     def query(self, url_path, payload=None):
         return self.send_request("GET", url_path, payload=payload)
 
@@ -282,6 +287,11 @@ class Resource(object):
 
     def __init__(self, api_key=None, api=None, **kwargs):
         self._api = api if api is not None else API(api_key, **kwargs)
+
+    def __repr__(self):
+        return "{}(base_url={!r}, has_key={})".format(
+            type(self).__name__, self._api.base_url, bool(self._api.api_key)
+        )
 
     def request_endpoint(self, op_id, **params):
         return self._api.request_endpoint(op_id, **params)

--- a/datamaxi/lib/utils.py
+++ b/datamaxi/lib/utils.py
@@ -1,6 +1,5 @@
 from typing import List
 from urllib.parse import urlencode
-import pandas as pd
 from functools import wraps
 from datamaxi.error import ParameterRequiredError
 from datamaxi.error import AtLeastOneParameterRequiredError
@@ -70,6 +69,8 @@ def encoded_string(query):
 
 
 def convert_to_df(data, header: bool, index: str = None, apply_fn={}):
+    import pandas as pd
+
     df = pd.DataFrame(data)
 
     if header:

--- a/datamaxi/naver/__init__.py
+++ b/datamaxi/naver/__init__.py
@@ -1,9 +1,13 @@
-from typing import Any, List, Union
-import pandas as pd
+from __future__ import annotations
+
+from typing import Any, List, Union, TYPE_CHECKING
 from datamaxi.api import Resource
 from datamaxi.resources.responses import NaverTrendRow
 from datamaxi.lib.utils import check_required_parameter
 from datamaxi.lib.constants import BASE_URL
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class Naver(Resource):
@@ -51,5 +55,7 @@ class Naver(Resource):
         check_required_parameter(symbol, "symbol")
         res = self.request_endpoint("naver_trend", symbol=symbol)
         if pandas:
+            import pandas as pd
+
             return pd.DataFrame(res)
         return res

--- a/datamaxi/resources/__init__.py
+++ b/datamaxi/resources/__init__.py
@@ -47,6 +47,7 @@ class Datamaxi:
         # pool threaded through every sub-client instead of each opening
         # its own. Sub-clients receive it via `api=` and forward it down.
         api = API(api_key, **kwargs)
+        self._api = api
 
         self.cex = Cex(api=api)
         self.funding_rate = FundingRate(api=api)
@@ -62,3 +63,8 @@ class Datamaxi:
         self.open_interest = OpenInterest(api=api)
         self.margin_borrow = MarginBorrow(api=api)
         self.index_price = IndexPrice(api=api)
+
+    def __repr__(self):
+        return "Datamaxi(base_url={!r}, has_key={})".format(
+            self._api.base_url, bool(self._api.api_key)
+        )

--- a/datamaxi/resources/cex_candle.py
+++ b/datamaxi/resources/cex_candle.py
@@ -1,11 +1,15 @@
-from typing import Any, List, Dict, Union, Optional
-import pandas as pd
+from __future__ import annotations
+
+from typing import Any, List, Dict, Union, Optional, TYPE_CHECKING
 from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameter
 from datamaxi.lib.utils import check_required_parameters
 from datamaxi.resources.utils import convert_data_to_data_frame
 from datamaxi.resources.responses import CandleResponse
 from datamaxi.lib.constants import SPOT, FUTURES, INTERVAL_1D, USD, Market, Interval
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class CexCandle(Resource):

--- a/datamaxi/resources/cex_ticker.py
+++ b/datamaxi/resources/cex_ticker.py
@@ -1,9 +1,13 @@
-from typing import Any, List, Union
-import pandas as pd
+from __future__ import annotations
+
+from typing import Any, List, Union, TYPE_CHECKING
 from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameters
 from datamaxi.resources.responses import TickerResponse
 from datamaxi.lib.constants import SPOT, FUTURES, Market
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class CexTicker(Resource):
@@ -70,6 +74,8 @@ class CexTicker(Resource):
         )
 
         if pandas:
+            import pandas as pd
+
             df = pd.DataFrame([res["data"]])
             df = df.set_index("d")
             return df

--- a/datamaxi/resources/cex_wallet_status.py
+++ b/datamaxi/resources/cex_wallet_status.py
@@ -1,9 +1,13 @@
-from typing import Any, List, Union
-import pandas as pd
+from __future__ import annotations
+
+from typing import Any, List, Union, TYPE_CHECKING
 from datamaxi.api import Resource
 from datamaxi.resources.responses import WalletStatusRow
 from datamaxi.lib.utils import check_required_parameters
 from datamaxi.lib.utils import check_required_parameter
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class CexWalletStatus(Resource):
@@ -47,6 +51,8 @@ class CexWalletStatus(Resource):
 
         res = self.request_endpoint("wallet_status", exchange=exchange, asset=asset)
         if pandas:
+            import pandas as pd
+
             df = pd.DataFrame(res)
             df = df.set_index("network")
             return df

--- a/datamaxi/resources/forex.py
+++ b/datamaxi/resources/forex.py
@@ -1,8 +1,12 @@
-from typing import Any, List, Union
-import pandas as pd
+from __future__ import annotations
+
+from typing import Any, List, Union, TYPE_CHECKING
 from datamaxi.api import Resource
 from datamaxi.resources.responses import ForexRow
 from datamaxi.lib.utils import check_required_parameter
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class Forex(Resource):
@@ -43,6 +47,8 @@ class Forex(Resource):
         res = self.request_endpoint("forex", symbol=symbol)
 
         if pandas:
+            import pandas as pd
+
             return pd.DataFrame([res])
         else:
             return res

--- a/datamaxi/resources/funding_rate.py
+++ b/datamaxi/resources/funding_rate.py
@@ -1,11 +1,15 @@
-from typing import Any, Callable, Tuple, List, Union
-import pandas as pd
+from __future__ import annotations
+
+from typing import Any, Callable, Tuple, List, Union, TYPE_CHECKING
 from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameter
 from datamaxi.lib.utils import check_required_parameters
 from datamaxi.resources.utils import convert_data_to_data_frame
 from datamaxi.resources.responses import FundingHistoryResponse, LatestFundingRate
 from datamaxi.lib.constants import ASC, DESC, SortOrder
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class FundingRate(Resource):
@@ -126,6 +130,8 @@ class FundingRate(Resource):
         )
 
         if pandas:
+            import pandas as pd
+
             df = pd.DataFrame([res])
             df = df.set_index("d")
             return df

--- a/datamaxi/resources/premium.py
+++ b/datamaxi/resources/premium.py
@@ -1,8 +1,12 @@
-from typing import Any, List, Union, Optional
-import pandas as pd
+from __future__ import annotations
+
+from typing import Any, List, Union, Optional, TYPE_CHECKING
 from datamaxi.api import Resource
 from datamaxi.resources.responses import PremiumResponse
 from datamaxi.lib.constants import Market, SortOrder
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class Premium(Resource):
@@ -148,6 +152,8 @@ class Premium(Resource):
             raise ValueError("no data found")
 
         if pandas:
+            import pandas as pd
+
             df = pd.DataFrame(
                 [
                     {

--- a/datamaxi/resources/utils.py
+++ b/datamaxi/resources/utils.py
@@ -1,11 +1,17 @@
-from typing import List
-import pandas as pd
+from __future__ import annotations
+
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def convert_data_to_data_frame(
     data: List,
     columns_to_replace: List[str] = [],
 ) -> pd.DataFrame:
+    import pandas as pd
+
     df = pd.DataFrame(data)
     df = df.set_index("d")
 

--- a/tests/test_repr_and_lazy_pandas.py
+++ b/tests/test_repr_and_lazy_pandas.py
@@ -1,0 +1,42 @@
+"""Tests for the #143 polish: __repr__ and lazy pandas import."""
+
+import subprocess
+import sys
+
+from datamaxi import Datamaxi
+from datamaxi.api import API
+
+BASE_URL = "https://api.datamaxiplus.com"
+
+
+def test_api_repr():
+    r = repr(API(api_key="secret", base_url=BASE_URL))
+    assert r == "API(base_url='https://api.datamaxiplus.com', has_key=True)"
+    assert "secret" not in r
+
+
+def test_resource_repr_uses_class_name():
+    c = Datamaxi(api_key="secret", base_url=BASE_URL)
+    assert repr(c.cex) == "Cex(base_url='https://api.datamaxiplus.com', has_key=True)"
+    assert (
+        repr(c.cex.candle)
+        == "CexCandle(base_url='https://api.datamaxiplus.com', has_key=True)"
+    )
+    assert "secret" not in repr(c.cex.candle)
+
+
+def test_datamaxi_repr_and_no_key_leak(monkeypatch):
+    c = Datamaxi(api_key="secret", base_url=BASE_URL)
+    assert repr(c) == "Datamaxi(base_url='https://api.datamaxiplus.com', has_key=True)"
+    assert "secret" not in repr(c)
+    # has_key=False only holds with no key from arg *or* environment
+    monkeypatch.delenv("DATAMAXI_API_KEY", raising=False)
+    assert "has_key=False" in repr(Datamaxi(base_url=BASE_URL))
+
+
+def test_importing_datamaxi_does_not_load_pandas():
+    # Isolated subprocess: other tests in this session load pandas, so a
+    # same-process sys.modules check would be unreliable.
+    code = "import sys, datamaxi; " "sys.exit(0 if 'pandas' not in sys.modules else 1)"
+    result = subprocess.run([sys.executable, "-c", code])
+    assert result.returncode == 0, "importing datamaxi should not import pandas"


### PR DESCRIPTION
Closes #143

Two independent polish items from #143.

## 1. `__repr__` on clients
`API`, `Resource`, and `Datamaxi` now render readably instead of `<...object at 0x...>`:

```
Datamaxi(base_url='https://api.datamaxiplus.com', has_key=True)
CexCandle(base_url='https://api.datamaxiplus.com', has_key=True)
```

`has_key` is a bool — the API key is never included in the repr.

## 2. Lazy pandas import (approach: keep required, import lazily)
`pandas` was imported at module top in `lib/utils.py` (and every resource module), and since `api.py` pulls in `lib/utils`, **every `import datamaxi` loaded pandas** — a heavy dependency users pay for even when they never build a DataFrame.

Now the top-level `import pandas as pd` is gone; pandas is imported **inside** the DataFrame code paths. To keep the `pd.DataFrame` return hints valid without the eager import, each affected file uses `from __future__ import annotations` (lazy string annotations) plus a `TYPE_CHECKING`-guarded import for static checkers.

pandas **stays a required dependency** (since `pandas=True` is the default return, per our discussion — not made an optional extra, which would break the default out of the box). It's just not *loaded* until a DataFrame is actually built.

**Verified:**
- `import datamaxi` → pandas **not** in `sys.modules`; still not loaded even after a `pandas=False` call.
- `pandas=True` still returns a `DataFrame` (pandas loaded on demand at that point).

## Tests
- New `tests/test_repr_and_lazy_pandas.py`: repr format + key-non-leak for API/Resource/Datamaxi, and a subprocess-isolated assertion that importing datamaxi doesn't import pandas (isolated because other tests in the session load pandas).
- `pytest -m "not integration"`: **155 passed, 11 skipped**.
- black + flake8 clean.

## Known failures
None.