### PR TITLE
#151 fix _dispatch_request str fallback (TypeError)

### DIFF
--- a/datamaxi/api.py
+++ b/datamaxi/api.py
@@ -200,7 +200,7 @@ class API(object):
             "DELETE": self.session.delete,
             "PUT": self.session.put,
             "POST": self.session.post,
-        }.get(http_method, "GET")
+        }.get(http_method, self.session.get)
 
     def _handle_exception(self, response):
         raise_for_error(response.status_code, response.text, response.headers)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -134,3 +134,9 @@ def test_API_context_manager_closes_session():
         client.session.close = lambda: setattr(client.session, "closed", True)
         assert client.__enter__() is client
     assert client.session.closed is True
+
+
+def test_dispatch_request_unknown_method_falls_back_to_get():
+    """Unknown HTTP methods should fall back to a callable (session.get), not a string."""
+    client = API()
+    assert client._dispatch_request("PATCH") == client.session.get


### PR DESCRIPTION
Closes #151

## Summary
`API._dispatch_request` fallback was the literal string `"GET"` — an unknown HTTP method would do `"GET"(**params)` → `TypeError: 'str' object is not callable`. Fallback now returns the callable `self.session.get`.

## Tests
- Added `test_dispatch_request_unknown_method_falls_back_to_get`.
- Full suite: 173 passed, 118 skipped.
