### PR TITLE
#156 error-handling hygiene

### DIFF
--- a/datamaxi/_dispatch.py
+++ b/datamaxi/_dispatch.py
@@ -71,11 +71,11 @@ def raise_for_error(status_code, text, headers):
         try:
             err = json.loads(text)
         except JSONDecodeError:
-            raise ClientError(status_code, text, None, headers)
+            raise ClientError(status_code, text, None, headers) from None
         error_data = None
         if "data" in err:
             error_data = err["data"]
-        raise ClientError(status_code, err["error"], headers, error_data)
+        raise ClientError(status_code, err.get("error", text), headers, error_data)
     raise ServerError(status_code, text)
 
 

--- a/datamaxi/error.py
+++ b/datamaxi/error.py
@@ -12,12 +12,14 @@ class ClientError(Error):
         self.header = header
         # return data if it's returned from server
         self.error_data = error_data
+        super().__init__(f"{status_code}: {error_message}")
 
 
 class ServerError(Error):
     def __init__(self, status_code, message):
         self.status_code = status_code
         self.message = message
+        super().__init__(f"{status_code}: {message}")
 
 
 class ParameterRequiredError(Error):

--- a/datamaxi/lib/utils.py
+++ b/datamaxi/lib/utils.py
@@ -45,7 +45,7 @@ def check_at_least_one_set_parameters(params):
             check_required_parameter(p[0], p[1])
             at_least_one_set = True
             break
-        except:  # noqa: E722
+        except ParameterRequiredError:
             pass
 
     if not at_least_one_set:


### PR DESCRIPTION
Closes #156

## Summary
Error-handling hygiene (4 fixes):
- `_dispatch.py`: `err["error"]` → `err.get("error", text)` (no more KeyError masking real 4xx body).
- `_dispatch.py`: `raise ClientError(...) from None` in the JSONDecodeError handler.
- `lib/utils.py`: bare `except:` → `except ParameterRequiredError:`.
- `error.py`: `ClientError`/`ServerError` now call `super().__init__(...)` so `str(err)` is informative; existing attrs preserved.

## Tests
- 172 passed, 118 skipped. flake8 clean. No test asserted empty `str(err)`.
