### PR TITLE
#152 ship py.typed marker (PEP 561)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include requirements/common.txt
+include datamaxi/py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ async = ["httpx>=0.27,<1"]
 dependencies = {file = ["requirements/common.txt"]}
 version = {attr = "datamaxi.__version__.__version__"}
 
+[tool.setuptools.package-data]
+datamaxi = ["py.typed"]
+
 [project.urls]
 Homepage = "https://github.com/bisonai/datamaxi-python"
 Issues = "https://github.com/bisonai/datamaxi-python/issues"


### PR DESCRIPTION
Closes #152

## Summary
Ship PEP 561 `py.typed` so downstream mypy/pyright consumers get the package's type hints.
- New empty `datamaxi/py.typed`.
- `[tool.setuptools.package-data]` + `MANIFEST.in` include (belt-and-suspenders for sdist).

## Tests
- Verified `py.typed` lands in both built wheel and sdist (`uv build`).
- 172 passed.
