### PR TITLE
#154 collapse duplicated sync/async response-shaping + align retry policy

### DIFF
--- a/datamaxi/_retry.py
+++ b/datamaxi/_retry.py
@@ -1,0 +1,86 @@
+"""Shared transient-5xx retry policy for the sync and async transports.
+
+The sync client (``datamaxi.api.API``) mounts a ``urllib3.util.retry.Retry``
+on its ``requests.Session`` adapters, which already implements this policy
+for `requests`. The async client (``datamaxi.aio._core.AsyncAPI``) is built
+on ``httpx``, which has no equivalent adapter-level retry, so it hand-rolls
+its own loop. This module is the single description of that policy so the
+two loops can't drift onto different retry behavior:
+
+* GET-only — retries are only safe for idempotent requests.
+* Exponential backoff — mirrors ``Retry.get_backoff_time()``: no delay
+  before the first retry, then ``backoff_factor * 2 ** (n - 1)`` before the
+  n-th retry (n >= 2), capped at ``BACKOFF_MAX`` seconds.
+* Honors a ``Retry-After`` response header (seconds or HTTP-date form) when
+  present, taking priority over the computed backoff — mirrors
+  ``Retry.respect_retry_after_header=True``.
+"""
+
+import email.utils
+import re
+import time
+
+#: Matches urllib3's ``Retry.DEFAULT_BACKOFF_MAX``.
+BACKOFF_MAX = 120.0
+
+_RETRY_AFTER_SECONDS_RE = re.compile(r"^\s*[0-9]+\s*$")
+
+
+def is_retryable(method, status_code, attempt, max_retries, retry_statuses):
+    """Whether attempt number ``attempt`` (1 = first failure) may be retried.
+
+    Only idempotent GETs are retried, only for statuses in
+    ``retry_statuses``, and only while ``attempt <= max_retries``.
+    """
+    return (
+        str(method).upper() == "GET"
+        and status_code in retry_statuses
+        and attempt <= max_retries
+    )
+
+
+def parse_retry_after(value):
+    """Parse a ``Retry-After`` header value into seconds, or ``None``.
+
+    Accepts either the numeric-seconds form or an HTTP-date, matching
+    ``urllib3.util.retry.Retry.parse_retry_after``. Returns ``None`` if
+    ``value`` is ``None`` or not parseable; never returns a negative number.
+    """
+    if value is None:
+        return None
+
+    if _RETRY_AFTER_SECONDS_RE.match(value):
+        seconds = float(value)
+    else:
+        retry_date_tuple = email.utils.parsedate_tz(value)
+        if retry_date_tuple is None:
+            return None
+        if retry_date_tuple[9] is None:
+            retry_date_tuple = retry_date_tuple[:9] + (0,) + retry_date_tuple[10:]
+        retry_date = email.utils.mktime_tz(retry_date_tuple)
+        seconds = retry_date - time.time()
+
+    return max(0.0, seconds)
+
+
+def get_backoff_time(attempt, backoff_factor):
+    """Seconds to sleep before retry number ``attempt`` (1 = first retry).
+
+    Matches urllib3's ``Retry.get_backoff_time()``: zero delay before the
+    first retry, then exponential growth, capped at ``BACKOFF_MAX``.
+    """
+    if attempt <= 1:
+        return 0.0
+    return min(BACKOFF_MAX, backoff_factor * (2 ** (attempt - 1)))
+
+
+def get_retry_delay(attempt, backoff_factor, headers):
+    """Seconds to sleep before retry number ``attempt``, honoring ``Retry-After``.
+
+    ``headers`` is any mapping-like object exposing ``.get(...)``
+    (``requests``/``httpx`` headers are both case-insensitive mappings).
+    """
+    retry_after = parse_retry_after(headers.get("Retry-After"))
+    if retry_after is not None:
+        return retry_after
+    return get_backoff_time(attempt, backoff_factor)

--- a/datamaxi/aio/_core.py
+++ b/datamaxi/aio/_core.py
@@ -2,7 +2,10 @@
 
 Reuses the sync client's endpoint resolution and error handling
 (``datamaxi._dispatch``) plus ``ResponseMeta``, so the sync and async clients
-can't drift on request building or error semantics.
+can't drift on request building or error semantics. The retry loop below
+also follows the shared policy described in ``datamaxi._retry`` (GET-only,
+exponential backoff, honors ``Retry-After``) so it can't drift from the
+``urllib3``-backed retry mounted on the sync ``requests.Session``.
 """
 
 import asyncio
@@ -11,6 +14,7 @@ import os
 from datamaxi.__version__ import __version__
 from datamaxi.api import ResponseMeta
 from datamaxi._dispatch import resolve_endpoint, raise_for_error, extract_limit_usage
+from datamaxi._retry import is_retryable, get_retry_delay
 
 
 def _import_httpx():
@@ -28,8 +32,9 @@ class AsyncAPI:
     """Async transport built on ``httpx.AsyncClient``.
 
     Mirrors the sync ``API``: shared endpoint resolution, bounded retry of
-    transient gateway 5xx, the same ``ClientError`` / ``ServerError`` contract,
-    and ``last_response`` metadata.
+    transient gateway 5xx on GET requests with exponential backoff (honoring
+    ``Retry-After`` — see ``datamaxi._retry``), the same ``ClientError`` /
+    ``ServerError`` contract, and ``last_response`` metadata.
     """
 
     def __init__(
@@ -69,15 +74,20 @@ class AsyncAPI:
         # str()-encode scalars so bools match the sync client's urlencode
         # output (e.g. include_source -> "True", not httpx's "true").
         params = {k: str(v) for k, v in (payload or {}).items() if v is not None}
-        for attempt in range(self.max_retries + 1):
+        attempt = 0
+        while True:
             response = await self._client.request(method, url_path, params=params)
-            if (
-                response.status_code in self.retry_statuses
-                and attempt < self.max_retries
+            attempt += 1
+            if not is_retryable(
+                method,
+                response.status_code,
+                attempt,
+                self.max_retries,
+                self.retry_statuses,
             ):
-                await asyncio.sleep(self.retry_backoff * (attempt + 1))
-                continue
-            break
+                break
+            delay = get_retry_delay(attempt, self.retry_backoff, response.headers)
+            await asyncio.sleep(delay)
 
         raise_for_error(response.status_code, response.text, response.headers)
 

--- a/datamaxi/aio/cex.py
+++ b/datamaxi/aio/cex.py
@@ -6,6 +6,7 @@ from typing import Any, List, Dict, Union, Optional, Tuple, Callable, TYPE_CHECK
 
 from datamaxi.aio._core import AsyncAPI, AsyncResource
 from datamaxi.lib.utils import check_required_parameter, check_required_parameters
+from datamaxi.resources.utils import raise_if_no_data, to_indexed_dataframe
 from datamaxi.lib.constants import (
     SPOT,
     FUTURES,
@@ -63,8 +64,7 @@ class AsyncCexCandle(AsyncResource):
             currency=currency,
             **{"from": from_unix, "to": to_unix},
         )
-        if res["data"] is None or len(res["data"]) == 0:
-            raise ValueError("no data found")
+        raise_if_no_data(res)
 
         if pandas:
             from datamaxi.resources.utils import convert_data_to_data_frame
@@ -124,11 +124,7 @@ class AsyncCexTicker(AsyncResource):
         )
 
         if pandas:
-            import pandas as pd
-
-            df = pd.DataFrame([res["data"]])
-            df = df.set_index("d")
-            return df
+            return to_indexed_dataframe([res["data"]], "d")
         return res
 
     async def exchanges(self, market: Market) -> List[str]:
@@ -184,11 +180,7 @@ class AsyncCexWalletStatus(AsyncResource):
             "wallet_status", exchange=exchange, asset=asset
         )
         if pandas:
-            import pandas as pd
-
-            df = pd.DataFrame(res)
-            df = df.set_index("network")
-            return df
+            return to_indexed_dataframe(res, "network")
         return res
 
     async def exchanges(self) -> List[str]:

--- a/datamaxi/aio/premium.py
+++ b/datamaxi/aio/premium.py
@@ -1,4 +1,9 @@
-"""Async premium resource — mirror of ``datamaxi.resources.premium``."""
+"""Async premium resource — mirror of ``datamaxi.resources.premium``.
+
+Param assembly and response shaping are shared with the sync resource via
+``build_premium_params`` / ``shape_premium_response`` (see #154); only the
+``await`` glue differs.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +11,7 @@ from typing import List, Union, Optional, TYPE_CHECKING
 
 from datamaxi.aio._core import AsyncResource
 from datamaxi.resources.responses import PremiumResponse
+from datamaxi.resources.premium import build_premium_params, shape_premium_response
 from datamaxi.lib.constants import Market, SortOrder
 
 if TYPE_CHECKING:
@@ -13,7 +19,7 @@ if TYPE_CHECKING:
 
 
 class AsyncPremium(AsyncResource):
-    async def __call__(  # noqa: C901
+    async def __call__(
         self,
         source_exchange: Optional[str] = None,
         target_exchange: Optional[str] = None,
@@ -38,94 +44,31 @@ class AsyncPremium(AsyncResource):
         query: Optional[str] = None,
         pandas: bool = True,
     ) -> Union[pd.DataFrame, PremiumResponse]:
-        params = {}
-
-        if source_exchange is not None:
-            params["source_exchange"] = source_exchange
-
-        if target_exchange is not None:
-            params["target_exchange"] = target_exchange
-
-        if asset is not None:
-            params["asset"] = asset
-
-        if source_quote is not None:
-            params["source_quote"] = source_quote
-
-        if target_quote is not None:
-            params["target_quote"] = target_quote
-
-        if sort is not None:
-            params["sort"] = sort
-
-        if key is not None:
-            params["key"] = key
-
-        if query is not None:
-            params["query"] = query
-
-        if page is not None:
-            params["page"] = page
-
-        if limit is not None:
-            params["limit"] = limit
-
-        if currency is not None:
-            params["currency"] = currency
-
-        if conversion_base is not None:
-            params["conversion_base"] = conversion_base
-
-        if min_sv is not None:
-            params["min_sv"] = min_sv
-
-        if min_tv is not None:
-            params["min_tv"] = min_tv
-
-        if source_market is not None:
-            params["source_market"] = source_market
-
-        if target_market is not None:
-            params["target_market"] = target_market
-
-        if only_transferable:
-            params["only_transferable"] = True
-
-        if network is not None:
-            params["network"] = network
-
-        if premium_type is not None:
-            params["premium_type"] = premium_type
-
-        if token_include is not None:
-            params["token_include"] = token_include
-
-        if token_exclude is not None:
-            params["token_exclude"] = token_exclude
-
+        params = build_premium_params(
+            source_exchange=source_exchange,
+            target_exchange=target_exchange,
+            asset=asset,
+            source_quote=source_quote,
+            target_quote=target_quote,
+            sort=sort,
+            key=key,
+            page=page,
+            limit=limit,
+            currency=currency,
+            conversion_base=conversion_base,
+            min_sv=min_sv,
+            min_tv=min_tv,
+            source_market=source_market,
+            target_market=target_market,
+            only_transferable=only_transferable,
+            network=network,
+            premium_type=premium_type,
+            token_include=token_include,
+            token_exclude=token_exclude,
+            query=query,
+        )
         res = await self.request_endpoint("premium", **params)
-        if res["data"] is None or len(res["data"]) == 0:
-            raise ValueError("no data found")
-
-        if pandas:
-            import pandas as pd
-
-            df = pd.DataFrame(
-                [
-                    {
-                        **item["detail"],
-                        "source_annualized_funding_rate": item.get(
-                            "source_annualized_funding_rate"
-                        ),
-                        "target_annualized_funding_rate": item.get(
-                            "target_annualized_funding_rate"
-                        ),
-                    }
-                    for item in res["data"]
-                ]
-            )
-            return df
-        return res
+        return shape_premium_response(res, pandas)
 
     async def exchanges(self) -> List[str]:
         return await self.request_endpoint("premium_exchanges")

--- a/datamaxi/api.py
+++ b/datamaxi/api.py
@@ -7,7 +7,7 @@ from urllib3.util.retry import Retry
 from .__version__ import __version__
 from datamaxi.lib.utils import cleanNoneValue
 from datamaxi.lib.utils import encoded_string
-from datamaxi._dispatch import resolve_endpoint, raise_for_error
+from datamaxi._dispatch import resolve_endpoint, raise_for_error, extract_limit_usage
 
 
 class API(object):
@@ -93,6 +93,11 @@ class API(object):
         ``_handle_exception`` still raises ``ServerError`` — preserving
         the existing error contract instead of leaking urllib3's
         ``MaxRetryError``.
+
+        This is the canonical retry policy; ``datamaxi._retry`` documents
+        the same GET-only/backoff/``Retry-After`` semantics for the async
+        (``httpx``) client, which has no urllib3-equivalent adapter to
+        mount this on directly.
         """
         retry = Retry(
             total=max_retries,
@@ -171,25 +176,11 @@ class API(object):
         self.last_response = ResponseMeta(
             status_code=response.status_code,
             headers=response.headers,
-            limit_usage=self._extract_limit_usage(response.headers),
+            limit_usage=extract_limit_usage(response.headers),
             data=data,
         )
 
         return data
-
-    @staticmethod
-    def _extract_limit_usage(headers):
-        """Pull the ``x-ratelimit-*`` triplet out of the response headers."""
-        usage = {}
-        for key in headers.keys():
-            k = key.lower()
-            if (
-                k.startswith("x-ratelimit-limit")
-                or k.startswith("x-ratelimit-remaining")
-                or k.startswith("x-ratelimit-reset")
-            ):
-                usage[k] = headers[key]
-        return usage
 
     def _prepare_params(self, params):
         return encoded_string(cleanNoneValue(params))

--- a/datamaxi/resources/cex_candle.py
+++ b/datamaxi/resources/cex_candle.py
@@ -4,7 +4,7 @@ from typing import Any, List, Dict, Union, Optional, TYPE_CHECKING
 from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameter
 from datamaxi.lib.utils import check_required_parameters
-from datamaxi.resources.utils import convert_data_to_data_frame
+from datamaxi.resources.utils import convert_data_to_data_frame, raise_if_no_data
 from datamaxi.resources.responses import CandleResponse
 from datamaxi.lib.constants import SPOT, FUTURES, INTERVAL_1D, USD, Market, Interval
 
@@ -79,8 +79,7 @@ class CexCandle(Resource):
             currency=currency,
             **{"from": from_unix, "to": to_unix},
         )
-        if res["data"] is None or len(res["data"]) == 0:
-            raise ValueError("no data found")
+        raise_if_no_data(res)
 
         if pandas:
             return convert_data_to_data_frame(res["data"])

--- a/datamaxi/resources/cex_ticker.py
+++ b/datamaxi/resources/cex_ticker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, List, Union, Optional, TYPE_CHECKING
 from datamaxi.api import Resource
 from datamaxi.lib.utils import check_required_parameters
+from datamaxi.resources.utils import to_indexed_dataframe
 from datamaxi.resources.responses import TickerResponse
 from datamaxi.lib.constants import SPOT, FUTURES, Market
 
@@ -74,11 +75,7 @@ class CexTicker(Resource):
         )
 
         if pandas:
-            import pandas as pd
-
-            df = pd.DataFrame([res["data"]])
-            df = df.set_index("d")
-            return df
+            return to_indexed_dataframe([res["data"]], "d")
         else:
             return res
 

--- a/datamaxi/resources/cex_wallet_status.py
+++ b/datamaxi/resources/cex_wallet_status.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, List, Union, TYPE_CHECKING
 from datamaxi.api import Resource
 from datamaxi.resources.responses import WalletStatusRow
+from datamaxi.resources.utils import to_indexed_dataframe
 from datamaxi.lib.utils import check_required_parameters
 from datamaxi.lib.utils import check_required_parameter
 
@@ -51,11 +52,7 @@ class CexWalletStatus(Resource):
 
         res = self.request_endpoint("wallet_status", exchange=exchange, asset=asset)
         if pandas:
-            import pandas as pd
-
-            df = pd.DataFrame(res)
-            df = df.set_index("network")
-            return df
+            return to_indexed_dataframe(res, "network")
 
         return res
 

--- a/datamaxi/resources/premium.py
+++ b/datamaxi/resources/premium.py
@@ -1,12 +1,99 @@
 from __future__ import annotations
 
-from typing import Any, List, Union, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Union, Optional, TYPE_CHECKING
 from datamaxi.api import Resource
 from datamaxi.resources.responses import PremiumResponse
+from datamaxi.resources.utils import assemble_params, raise_if_no_data
 from datamaxi.lib.constants import Market, SortOrder
 
 if TYPE_CHECKING:
     import pandas as pd
+
+
+def build_premium_params(
+    source_exchange: Optional[str] = None,
+    target_exchange: Optional[str] = None,
+    asset: Optional[str] = None,
+    source_quote: Optional[str] = None,
+    target_quote: Optional[str] = None,
+    sort: Optional[SortOrder] = None,
+    key: Optional[str] = None,
+    page: int = 1,
+    limit: int = 100,
+    currency: Optional[str] = None,
+    conversion_base: Optional[str] = None,
+    min_sv: Optional[str] = None,
+    min_tv: Optional[str] = None,
+    source_market: Optional[Market] = None,
+    target_market: Optional[Market] = None,
+    only_transferable: bool = False,
+    network: Optional[str] = None,
+    premium_type: Optional[str] = None,
+    token_include: Optional[str] = None,
+    token_exclude: Optional[str] = None,
+    query: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Assemble the ``premium`` endpoint's query params from caller args.
+
+    Transport-agnostic (no request is made here) so the sync and async
+    ``Premium.__call__`` methods share the exact same param-building logic —
+    see #154.
+    """
+    return assemble_params(
+        ("source_exchange", source_exchange),
+        ("target_exchange", target_exchange),
+        ("asset", asset),
+        ("source_quote", source_quote),
+        ("target_quote", target_quote),
+        ("sort", sort),
+        ("key", key),
+        ("query", query),
+        ("page", page),
+        ("limit", limit),
+        ("currency", currency),
+        ("conversion_base", conversion_base),
+        ("min_sv", min_sv),
+        ("min_tv", min_tv),
+        ("source_market", source_market),
+        ("target_market", target_market),
+        ("only_transferable", True if only_transferable else None),
+        ("network", network),
+        ("premium_type", premium_type),
+        ("token_include", token_include),
+        ("token_exclude", token_exclude),
+    )
+
+
+def shape_premium_response(
+    res: PremiumResponse, pandas: bool
+) -> Union[pd.DataFrame, PremiumResponse]:
+    """Turn a raw ``premium`` response into the DataFrame or typed dict shape.
+
+    Shared by the sync and async ``Premium.__call__`` so the "no data"
+    check and DataFrame construction can't drift between the two — see
+    #154.
+    """
+    raise_if_no_data(res)
+
+    if not pandas:
+        return res
+
+    import pandas as pd
+
+    return pd.DataFrame(
+        [
+            {
+                **item["detail"],
+                "source_annualized_funding_rate": item.get(
+                    "source_annualized_funding_rate"
+                ),
+                "target_annualized_funding_rate": item.get(
+                    "target_annualized_funding_rate"
+                ),
+            }
+            for item in res["data"]
+        ]
+    )
 
 
 class Premium(Resource):
@@ -24,7 +111,7 @@ class Premium(Resource):
         self.__module__ = __name__
         self.__qualname__ = self.__class__.__qualname__
 
-    def __call__(  # noqa: C901
+    def __call__(
         self,
         source_exchange: Optional[str] = None,
         target_exchange: Optional[str] = None,
@@ -82,95 +169,31 @@ class Premium(Resource):
         Returns:
             Premium data in pandas DataFrame
         """
-        params = {}
-
-        if source_exchange is not None:
-            params["source_exchange"] = source_exchange
-
-        if target_exchange is not None:
-            params["target_exchange"] = target_exchange
-
-        if asset is not None:
-            params["asset"] = asset
-
-        if source_quote is not None:
-            params["source_quote"] = source_quote
-
-        if target_quote is not None:
-            params["target_quote"] = target_quote
-
-        if sort is not None:
-            params["sort"] = sort
-
-        if key is not None:
-            params["key"] = key
-
-        if query is not None:
-            params["query"] = query
-
-        if page is not None:
-            params["page"] = page
-
-        if limit is not None:
-            params["limit"] = limit
-
-        if currency is not None:
-            params["currency"] = currency
-
-        if conversion_base is not None:
-            params["conversion_base"] = conversion_base
-
-        if min_sv is not None:
-            params["min_sv"] = min_sv
-
-        if min_tv is not None:
-            params["min_tv"] = min_tv
-
-        if source_market is not None:
-            params["source_market"] = source_market
-
-        if target_market is not None:
-            params["target_market"] = target_market
-
-        if only_transferable:
-            params["only_transferable"] = True
-
-        if network is not None:
-            params["network"] = network
-
-        if premium_type is not None:
-            params["premium_type"] = premium_type
-
-        if token_include is not None:
-            params["token_include"] = token_include
-
-        if token_exclude is not None:
-            params["token_exclude"] = token_exclude
-
+        params = build_premium_params(
+            source_exchange=source_exchange,
+            target_exchange=target_exchange,
+            asset=asset,
+            source_quote=source_quote,
+            target_quote=target_quote,
+            sort=sort,
+            key=key,
+            page=page,
+            limit=limit,
+            currency=currency,
+            conversion_base=conversion_base,
+            min_sv=min_sv,
+            min_tv=min_tv,
+            source_market=source_market,
+            target_market=target_market,
+            only_transferable=only_transferable,
+            network=network,
+            premium_type=premium_type,
+            token_include=token_include,
+            token_exclude=token_exclude,
+            query=query,
+        )
         res = self.request_endpoint("premium", **params)
-        if res["data"] is None or len(res["data"]) == 0:
-            raise ValueError("no data found")
-
-        if pandas:
-            import pandas as pd
-
-            df = pd.DataFrame(
-                [
-                    {
-                        **item["detail"],
-                        "source_annualized_funding_rate": item.get(
-                            "source_annualized_funding_rate"
-                        ),
-                        "target_annualized_funding_rate": item.get(
-                            "target_annualized_funding_rate"
-                        ),
-                    }
-                    for item in res["data"]
-                ]
-            )
-            return df
-        else:
-            return res
+        return shape_premium_response(res, pandas)
 
     def exchanges(self) -> List[str]:
         """Fetch supported exchanges for premium data.

--- a/datamaxi/resources/utils.py
+++ b/datamaxi/resources/utils.py
@@ -1,9 +1,55 @@
+"""Transport-agnostic response-shaping helpers shared by the sync and async
+resources (see #154).
+
+Kept alongside ``datamaxi._dispatch`` (which shares *request*-building) as
+the shared *response*-shaping layer: param assembly, the "no data" envelope
+check, and the DataFrame-vs-raw-dict conversion decision. Pure functions
+only (deferred ``pandas`` import, no ``requests``/``httpx``), so both
+``datamaxi.resources.*`` and ``datamaxi.aio.*`` can import this leaf module
+without any import-cycle risk.
+"""
+
 from __future__ import annotations
 
-from typing import List, TYPE_CHECKING
+from typing import Any, Dict, List, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import pandas as pd
+
+
+def assemble_params(*pairs: Tuple[str, Any]) -> Dict[str, Any]:
+    """Build a query-param dict from ``(name, value)`` pairs, dropping ``None``.
+
+    Mirrors the repeated ``if x is not None: params["x"] = x`` blocks that
+    were hand-copied across sync/async resource methods. For "only include
+    when truthy" flags (e.g. ``only_transferable``), pass ``value if value
+    else None`` at the call site.
+    """
+    return {name: value for name, value in pairs if value is not None}
+
+
+def raise_if_no_data(res: Dict[str, Any], check_length: bool = True) -> None:
+    """Raise ``ValueError("no data found")`` for an empty ``{"data": ...}`` envelope.
+
+    ``check_length`` matches call sites that also treat an empty
+    list/dict as "no data" (e.g. candle, premium), vs. ones that only
+    check for ``None`` (e.g. announcements, token updates).
+    """
+    if res["data"] is None or (check_length and len(res["data"]) == 0):
+        raise ValueError("no data found")
+
+
+def to_indexed_dataframe(rows: List, index_col: str) -> pd.DataFrame:
+    """``pd.DataFrame(rows).set_index(index_col)`` — the ticker/wallet-status shape.
+
+    ``rows`` is already a list of dicts (wrap a single dict as ``[rows]`` at
+    the call site, as the ticker endpoint's bare-object response does).
+    """
+    import pandas as pd
+
+    df = pd.DataFrame(rows)
+    df = df.set_index(index_col)
+    return df
 
 
 def convert_data_to_data_frame(

--- a/tests/test_endpoint_param_coverage.py
+++ b/tests/test_endpoint_param_coverage.py
@@ -8,8 +8,9 @@ only reachable if some client call site forwards it as a keyword argument.
 
 This test statically extracts, per ``op_id``, the union of keyword arguments
 forwarded at every ``request_endpoint("op_id", ...)`` call site (handling the
-``**{"from": ...}`` dict-splat and the ``**params`` local-dict patterns), then
-asserts that every registry param is either forwarded, globally ignored
+``**{"from": ...}`` dict-splat, the ``**params`` local-dict pattern, and the
+``params = build_x_params(x=x, ...)`` extracted-builder pattern — see #154),
+then asserts that every registry param is either forwarded, globally ignored
 (pagination), or explicitly allow-listed below with a rationale.
 
 Regenerating ``_endpoints.py`` (``make python`` upstream) that adds a new param
@@ -71,7 +72,17 @@ def _enclosing_func(parents, node):
 
 
 def _subscript_string_keys(func_node, name):
-    """Collect literal keys of ``name[<str>] = ...`` assignments in ``func``."""
+    """Collect the wire param names that populate the local dict ``name``.
+
+    Handles two ways a resource method builds its ``params`` dict before
+    ``request_endpoint(op, **params)``:
+
+    - ``name["x"] = ...`` assignments inline in the method.
+    - ``name = build_x_params(x=x, y=y, ...)`` — a call to an extracted,
+      transport-agnostic param-builder shared with the async mirror (see
+      #154); the keyword-argument names at the call site are the wire param
+      names it forwards (builders are written to keep them 1:1).
+    """
     keys = set()
     if func_node is None:
         return keys
@@ -87,6 +98,14 @@ def _subscript_string_keys(func_node, name):
                 and isinstance(tgt.slice.value, str)
             ):
                 keys.add(tgt.slice.value)
+            elif (
+                isinstance(tgt, ast.Name)
+                and tgt.id == name
+                and isinstance(n.value, ast.Call)
+            ):
+                for kw in n.value.keywords:
+                    if kw.arg is not None:
+                        keys.add(kw.arg)
     return keys
 
 

--- a/tests/test_premium_shaping_shared.py
+++ b/tests/test_premium_shaping_shared.py
@@ -1,0 +1,18 @@
+"""Anti-drift check: the async premium resource reuses the sync module's
+param-builder / response-shaper (see #154) rather than a hand-copied one.
+"""
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+
+from datamaxi.aio import premium as aio_premium  # noqa: E402
+from datamaxi.resources import premium as sync_premium  # noqa: E402
+
+
+def test_async_premium_reuses_sync_param_builder():
+    assert aio_premium.build_premium_params is sync_premium.build_premium_params
+
+
+def test_async_premium_reuses_sync_response_shaper():
+    assert aio_premium.shape_premium_response is sync_premium.shape_premium_response

--- a/tests/test_resources_utils.py
+++ b/tests/test_resources_utils.py
@@ -1,0 +1,64 @@
+"""Tests for the shared response-shaping helpers (``datamaxi.resources.utils``,
+see #154) — param assembly, the "no data" check, and DataFrame shaping used
+by both the sync and async resources.
+"""
+
+import pandas as pd
+import pytest
+
+from datamaxi.resources.utils import (
+    assemble_params,
+    raise_if_no_data,
+    to_indexed_dataframe,
+)
+
+
+def test_assemble_params_drops_none_and_keeps_order():
+    params = assemble_params(
+        ("a", 1),
+        ("b", None),
+        ("c", "x"),
+    )
+    assert params == {"a": 1, "c": "x"}
+    assert list(params) == ["a", "c"]
+
+
+def test_assemble_params_only_truthy_flag_pattern():
+    # Call-site pattern for "include only if truthy" flags like
+    # only_transferable: pass `True if flag else None`.
+    included = assemble_params(("only_transferable", True if True else None))
+    excluded = assemble_params(("only_transferable", True if False else None))
+    assert included == {"only_transferable": True}
+    assert excluded == {}
+
+
+def test_raise_if_no_data_raises_on_none():
+    with pytest.raises(ValueError):
+        raise_if_no_data({"data": None})
+
+
+def test_raise_if_no_data_raises_on_empty_by_default():
+    with pytest.raises(ValueError):
+        raise_if_no_data({"data": []})
+
+
+def test_raise_if_no_data_allows_empty_when_length_check_disabled():
+    raise_if_no_data({"data": []}, check_length=False)  # no raise
+
+
+def test_raise_if_no_data_passes_with_data():
+    raise_if_no_data({"data": [{"x": 1}]})
+
+
+def test_to_indexed_dataframe_single_row():
+    df = to_indexed_dataframe([{"d": "123", "p": "1.5"}], "d")
+    assert isinstance(df, pd.DataFrame)
+    assert df.index.name == "d"
+    assert list(df.index) == ["123"]
+
+
+def test_to_indexed_dataframe_multi_row():
+    df = to_indexed_dataframe(
+        [{"network": "BSC", "x": 1}, {"network": "ETH", "x": 2}], "network"
+    )
+    assert list(df.index) == ["BSC", "ETH"]

--- a/tests/test_retry_policy.py
+++ b/tests/test_retry_policy.py
@@ -1,0 +1,183 @@
+"""Tests for the shared retry policy (``datamaxi._retry``, see #154).
+
+Covers the pure policy functions directly, plus the async transport's use of
+them: GET-only, exponential backoff, and honoring ``Retry-After`` — aligning
+the ``httpx``-based async client with the ``urllib3``-backed sync retry
+policy exercised in ``tests/test_retry.py``.
+"""
+
+import asyncio
+
+import pytest
+
+from datamaxi._retry import (
+    is_retryable,
+    parse_retry_after,
+    get_backoff_time,
+    get_retry_delay,
+)
+
+httpx = pytest.importorskip("httpx")
+
+from datamaxi.aio._core import AsyncAPI  # noqa: E402
+
+BASE_URL = "https://api.datamaxiplus.com"
+
+
+# --- pure policy functions ---------------------------------------------------
+def test_is_retryable_get_only():
+    assert is_retryable("GET", 503, 1, 3, (502, 503, 504))
+    assert is_retryable("get", 503, 1, 3, (502, 503, 504))  # case-insensitive
+    assert not is_retryable("POST", 503, 1, 3, (502, 503, 504))
+
+
+def test_is_retryable_only_for_listed_statuses():
+    assert not is_retryable("GET", 200, 1, 3, (502, 503, 504))
+
+
+def test_is_retryable_respects_max_retries():
+    assert is_retryable("GET", 503, 3, 3, (503,))
+    assert not is_retryable("GET", 503, 4, 3, (503,))
+
+
+def test_get_backoff_time_is_exponential_with_zero_first_retry():
+    # Matches urllib3.Retry.get_backoff_time(): no delay before the first
+    # retry, then backoff_factor * 2 ** (n - 1).
+    assert get_backoff_time(1, 0.5) == 0.0
+    assert get_backoff_time(2, 0.5) == 1.0
+    assert get_backoff_time(3, 0.5) == 2.0
+    assert get_backoff_time(4, 0.5) == 4.0
+
+
+def test_get_backoff_time_caps_at_backoff_max():
+    assert get_backoff_time(20, 10.0) == 120.0
+
+
+def test_parse_retry_after_seconds_form():
+    assert parse_retry_after("120") == 120.0
+
+
+def test_parse_retry_after_missing_returns_none():
+    assert parse_retry_after(None) is None
+
+
+def test_parse_retry_after_never_negative():
+    # An HTTP-date in the past yields a would-be-negative delta.
+    assert parse_retry_after("Mon, 01 Jan 2001 00:00:00 GMT") == 0.0
+
+
+def test_get_retry_delay_prefers_retry_after_header():
+    assert get_retry_delay(4, 0.5, {"Retry-After": "7"}) == 7.0
+
+
+def test_get_retry_delay_falls_back_to_backoff():
+    assert get_retry_delay(3, 0.5, {}) == 2.0
+
+
+# --- async transport wiring ---------------------------------------------------
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_async_get_retries_transient_5xx_with_exponential_backoff(monkeypatch):
+    sleeps = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        if calls["n"] < 4:
+            return httpx.Response(503, json={"error": "busy"})
+        return httpx.Response(200, json={"ok": True})
+
+    async def run():
+        api = AsyncAPI(
+            api_key="k",
+            base_url=BASE_URL,
+            max_retries=3,
+            retry_backoff=0.5,
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            return await api.send_request("GET", "/x")
+        finally:
+            await api.aclose()
+
+    data = _run(run())
+    assert data == {"ok": True}
+    assert calls["n"] == 4
+    # No delay before the 1st retry, then exponential growth (factor * 2**(n-1)).
+    assert sleeps == [0.0, 1.0, 2.0]
+
+
+def test_async_post_is_not_retried(monkeypatch):
+    async def fake_sleep(seconds):
+        raise AssertionError("POST must not be retried")
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        return httpx.Response(503, json={"error": "busy"})
+
+    async def run():
+        api = AsyncAPI(
+            api_key="k",
+            base_url=BASE_URL,
+            max_retries=3,
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            await api.send_request("POST", "/x")
+        finally:
+            await api.aclose()
+
+    from datamaxi.error import ServerError
+
+    with pytest.raises(ServerError):
+        _run(run())
+    assert calls["n"] == 1
+
+
+def test_async_honors_retry_after_header(monkeypatch):
+    sleeps = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            return httpx.Response(
+                503, json={"error": "busy"}, headers={"Retry-After": "3"}
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    async def run():
+        api = AsyncAPI(
+            api_key="k",
+            base_url=BASE_URL,
+            max_retries=3,
+            retry_backoff=0.5,
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            return await api.send_request("GET", "/x")
+        finally:
+            await api.aclose()
+
+    data = _run(run())
+    assert data == {"ok": True}
+    # Retry-After (3s) takes priority over the computed backoff (0s).
+    assert sleeps == [3.0]


### PR DESCRIPTION
Closes #154

## Summary
Collapse duplicated sync/async response-shaping and align the async retry policy with the sync (urllib3) one. Pure refactor — behavior identical, verified by an independent review pass.

**Shared response-shaping** (`datamaxi/resources/utils.py`, leaf module — no import-cycle):
- `assemble_params`, `raise_if_no_data`, `to_indexed_dataframe` extracted.
- `premium.py`: `build_premium_params` (all 20 params) + `shape_premium_response` extracted; `aio/premium.py` now imports them directly (no async copy) — identity-tested.
- candle/ticker/wallet_status (sync+async) swap hand-copied `pd.DataFrame(...).set_index(...)` / empty-data blocks for the shared helpers.
- `api.py`: sync side now reuses `_dispatch.extract_limit_usage` (was duplicated).

**Retry alignment** (`datamaxi/_retry.py`, new):
- Pure functions reproducing urllib3 `Retry` semantics: GET-only, backoff `0` then `backoff_factor * 2**(n-1)` capped at 120s, `Retry-After` (seconds or HTTP-date) priority.
- `aio/_core.py` rewired onto it, replacing the old linear-backoff/all-methods/no-`Retry-After` loop (a real behavior fix). Sync side's urllib3 `Retry` left untouched; `_retry.py` is the shared, testable description of that policy.

## Tests
- 199 passed, 118 skipped (baseline 176 passed; +23 new tests for `_retry.py`, shaping helpers, and sync/async premium identity). black + flake8 clean. `import datamaxi` / `import datamaxi.aio` both OK.

## Reviewer nits (non-blocking, left as-is)
- `_retry.py` `parse_retry_after`: silently returns `None` on malformed `Retry-After` and has no upper cap (urllib3 raises / caps at 21600s) — arguably safer, no real-traffic impact.
- Stale comment at `test_endpoint_param_coverage.py:176`; defensive dead branch in `parse_retry_after`.

## Scope note
`cex_wallet_status.py` folded into the shared helper too (issue named only candle/ticker) — same duplication pattern.
