### PR TITLE
docs: replace Sync/Async MkDocs tabs with GitHub-native <details> blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,74 +84,78 @@ the key stays out of source code):
 export DATAMAXI_API_KEY="your_api_key"
 ```
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi, Telegram, Naver
+```python
+from datamaxi import Datamaxi, Telegram, Naver
 
-    # Clients read DATAMAXI_API_KEY from the environment automatically.
-    # Alternatively, pass api_key="your_api_key" explicitly to each client.
-    maxi = Datamaxi()
-    telegram = Telegram()
-    naver = Naver()
+# Clients read DATAMAXI_API_KEY from the environment automatically.
+# Alternatively, pass api_key="your_api_key" explicitly to each client.
+maxi = Datamaxi()
+telegram = Telegram()
+naver = Naver()
 
-    # Fetch CEX candle data (returns pandas DataFrame)
-    df = maxi.cex.candle(
-        exchange="binance",
-        symbol="BTC-USDT",
-        interval="1d",
-        market="spot"
-    )
-    print(df.head())
+# Fetch CEX candle data (returns pandas DataFrame)
+df = maxi.cex.candle(
+    exchange="binance",
+    symbol="BTC-USDT",
+    interval="1d",
+    market="spot"
+)
+print(df.head())
 
-    # Fetch ticker data
-    ticker = maxi.cex.ticker.get(
-        exchange="binance",
-        symbol="BTC-USDT",
-        market="spot"
-    )
-    print(ticker)
+# Fetch ticker data
+ticker = maxi.cex.ticker.get(
+    exchange="binance",
+    symbol="BTC-USDT",
+    market="spot"
+)
+print(ticker)
 
-    # Fetch premium data
-    premium = maxi.premium(asset="BTC")
-    print(premium.head())
-    ```
+# Fetch premium data
+premium = maxi.premium(asset="BTC")
+print(premium.head())
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        # Reads DATAMAXI_API_KEY from the environment automatically.
-        # Alternatively, pass api_key="your_api_key" explicitly.
-        async with AsyncDatamaxi() as client:
-            # Fetch CEX candle data (returns pandas DataFrame)
-            df = await client.cex.candle(
-                exchange="binance",
-                symbol="BTC-USDT",
-                interval="1d",
-                market="spot",
-            )
-            print(df.head())
-
-            # Fetch ticker data
-            ticker = await client.cex.ticker.get(
-                exchange="binance",
-                symbol="BTC-USDT",
-                market="spot",
-            )
-            print(ticker)
-
-            # Fetch premium data
-            premium = await client.premium(asset="BTC")
-            print(premium.head())
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    # Reads DATAMAXI_API_KEY from the environment automatically.
+    # Alternatively, pass api_key="your_api_key" explicitly.
+    async with AsyncDatamaxi() as client:
+        # Fetch CEX candle data (returns pandas DataFrame)
+        df = await client.cex.candle(
+            exchange="binance",
+            symbol="BTC-USDT",
+            interval="1d",
+            market="spot",
+        )
+        print(df.head())
+
+        # Fetch ticker data
+        ticker = await client.cex.ticker.get(
+            exchange="binance",
+            symbol="BTC-USDT",
+            market="spot",
+        )
+        print(ticker)
+
+        # Fetch premium data
+        premium = await client.premium(asset="BTC")
+        print(premium.head())
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Async Client
 

--- a/docs/cex-announcement.md
+++ b/docs/cex-announcement.md
@@ -4,46 +4,50 @@ Exchange announcements such as listings and delistings.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    data, next_request = maxi.cex.announcement(
-        exchange="binance",
-        category="listing",
-        page=1,
-        limit=50,
-        sort="desc",
-    )
+data, next_request = maxi.cex.announcement(
+    exchange="binance",
+    category="listing",
+    page=1,
+    limit=50,
+    sort="desc",
+)
 
-    more_data, _ = next_request()
-    ```
+more_data, _ = next_request()
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            data, next_request = await client.cex.announcement(
-                exchange="binance",
-                category="listing",
-                page=1,
-                limit=50,
-                sort="desc",
-            )
-
-            more_data, _ = await next_request()
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        data, next_request = await client.cex.announcement(
+            exchange="binance",
+            category="listing",
+            page=1,
+            limit=50,
+            sort="desc",
+        )
+
+        more_data, _ = await next_request()
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/cex-candle.md
+++ b/docs/cex-candle.md
@@ -4,52 +4,56 @@ Historical OHLCV candle data for centralized exchanges.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    exchanges = maxi.cex.candle.exchanges(market="spot")
-    symbols = maxi.cex.candle.symbols(exchange="binance", market="spot")
-    intervals = maxi.cex.candle.intervals()
+exchanges = maxi.cex.candle.exchanges(market="spot")
+symbols = maxi.cex.candle.symbols(exchange="binance", market="spot")
+intervals = maxi.cex.candle.intervals()
 
-    df = maxi.cex.candle(
-        exchange="binance",
-        symbol="BTC-USDT",
-        interval="1d",
-        market="spot",
-        from_unix=1704067200,
-        to_unix=1706745600,
-    )
-    ```
+df = maxi.cex.candle(
+    exchange="binance",
+    symbol="BTC-USDT",
+    interval="1d",
+    market="spot",
+    from_unix=1704067200,
+    to_unix=1706745600,
+)
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            exchanges = await client.cex.candle.exchanges(market="spot")
-            symbols = await client.cex.candle.symbols(exchange="binance", market="spot")
-            intervals = await client.cex.candle.intervals()
-
-            df = await client.cex.candle(
-                exchange="binance",
-                symbol="BTC-USDT",
-                interval="1d",
-                market="spot",
-                from_unix=1704067200,
-                to_unix=1706745600,
-            )
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        exchanges = await client.cex.candle.exchanges(market="spot")
+        symbols = await client.cex.candle.symbols(exchange="binance", market="spot")
+        intervals = await client.cex.candle.intervals()
+
+        df = await client.cex.candle(
+            exchange="binance",
+            symbol="BTC-USDT",
+            interval="1d",
+            market="spot",
+            from_unix=1704067200,
+            to_unix=1706745600,
+        )
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/cex-fee.md
+++ b/docs/cex-fee.md
@@ -4,36 +4,40 @@ Trading fee schedules for centralized exchanges.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    exchanges = maxi.cex.fee.exchanges()
-    symbols = maxi.cex.fee.symbols(exchange="binance")
+exchanges = maxi.cex.fee.exchanges()
+symbols = maxi.cex.fee.symbols(exchange="binance")
 
-    fees = maxi.cex.fee(exchange="binance", symbol="BTC-USDT")
-    ```
+fees = maxi.cex.fee(exchange="binance", symbol="BTC-USDT")
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            exchanges = await client.cex.fee.exchanges()
-            symbols = await client.cex.fee.symbols(exchange="binance")
-
-            fees = await client.cex.fee(exchange="binance", symbol="BTC-USDT")
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        exchanges = await client.cex.fee.exchanges()
+        symbols = await client.cex.fee.symbols(exchange="binance")
+
+        fees = await client.cex.fee(exchange="binance", symbol="BTC-USDT")
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/cex-symbol.md
+++ b/docs/cex-symbol.md
@@ -4,74 +4,78 @@ Per-base / per-symbol CEX metadata and aggregates: trading status, tags, caution
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    # Trading status + caution + tags + delisting metadata
-    metadata = maxi.cex.symbol.metadata(exchange="binance", base="BTC")
+# Trading status + caution + tags + delisting metadata
+metadata = maxi.cex.symbol.metadata(exchange="binance", base="BTC")
 
-    # Exchange-assigned tags (e.g. seed, alpha)
-    tags = maxi.cex.symbol.tags(exchange="binance", base="BTC")
+# Exchange-assigned tags (e.g. seed, alpha)
+tags = maxi.cex.symbol.tags(exchange="binance", base="BTC")
 
-    # Active caution / investment-warning flags
-    cautions = maxi.cex.symbol.cautions(exchange="binance")
+# Active caution / investment-warning flags
+cautions = maxi.cex.symbol.cautions(exchange="binance")
 
-    # Scheduled delistings with timestamps
-    delistings = maxi.cex.symbol.delistings(exchange="binance")
+# Scheduled delistings with timestamps
+delistings = maxi.cex.symbol.delistings(exchange="binance")
 
-    # Per-exchange 24h volume for a single base asset
-    volume = maxi.cex.symbol.volume(base="BTC")
+# Per-exchange 24h volume for a single base asset
+volume = maxi.cex.symbol.volume(base="BTC")
 
-    # Per-exchange Open Interest for a single base asset
-    oi = maxi.cex.symbol.oi(base="BTC", exchange="binance")
+# Per-exchange Open Interest for a single base asset
+oi = maxi.cex.symbol.oi(base="BTC", exchange="binance")
 
-    # Per-exchange OI snapshot with 1h / 4h / 24h deltas
-    oi_stats = maxi.cex.symbol.oi_stats(base="BTC", exchange="binance", currency="USD")
+# Per-exchange OI snapshot with 1h / 4h / 24h deltas
+oi_stats = maxi.cex.symbol.oi_stats(base="BTC", exchange="binance", currency="USD")
 
-    # Per-exchange long / short liquidation aggregates over a window
-    liquidation = maxi.cex.symbol.liquidation(base="BTC", window="24h")
-    ```
+# Per-exchange long / short liquidation aggregates over a window
+liquidation = maxi.cex.symbol.liquidation(base="BTC", window="24h")
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            # Trading status + caution + tags + delisting metadata
-            metadata = await client.cex.symbol.metadata(exchange="binance", base="BTC")
-
-            # Exchange-assigned tags (e.g. seed, alpha)
-            tags = await client.cex.symbol.tags(exchange="binance", base="BTC")
-
-            # Active caution / investment-warning flags
-            cautions = await client.cex.symbol.cautions(exchange="binance")
-
-            # Scheduled delistings with timestamps
-            delistings = await client.cex.symbol.delistings(exchange="binance")
-
-            # Per-exchange 24h volume for a single base asset
-            volume = await client.cex.symbol.volume(base="BTC")
-
-            # Per-exchange Open Interest for a single base asset
-            oi = await client.cex.symbol.oi(base="BTC", exchange="binance")
-
-            # Per-exchange OI snapshot with 1h / 4h / 24h deltas
-            oi_stats = await client.cex.symbol.oi_stats(base="BTC", exchange="binance", currency="USD")
-
-            # Per-exchange long / short liquidation aggregates over a window
-            liquidation = await client.cex.symbol.liquidation(base="BTC", window="24h")
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        # Trading status + caution + tags + delisting metadata
+        metadata = await client.cex.symbol.metadata(exchange="binance", base="BTC")
+
+        # Exchange-assigned tags (e.g. seed, alpha)
+        tags = await client.cex.symbol.tags(exchange="binance", base="BTC")
+
+        # Active caution / investment-warning flags
+        cautions = await client.cex.symbol.cautions(exchange="binance")
+
+        # Scheduled delistings with timestamps
+        delistings = await client.cex.symbol.delistings(exchange="binance")
+
+        # Per-exchange 24h volume for a single base asset
+        volume = await client.cex.symbol.volume(base="BTC")
+
+        # Per-exchange Open Interest for a single base asset
+        oi = await client.cex.symbol.oi(base="BTC", exchange="binance")
+
+        # Per-exchange OI snapshot with 1h / 4h / 24h deltas
+        oi_stats = await client.cex.symbol.oi_stats(base="BTC", exchange="binance", currency="USD")
+
+        # Per-exchange long / short liquidation aggregates over a window
+        liquidation = await client.cex.symbol.liquidation(base="BTC", window="24h")
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/cex-ticker.md
+++ b/docs/cex-ticker.md
@@ -4,46 +4,50 @@ Real-time ticker snapshots for centralized exchanges.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    exchanges = maxi.cex.ticker.exchanges(market="spot")
-    symbols = maxi.cex.ticker.symbols(exchange="binance", market="spot")
+exchanges = maxi.cex.ticker.exchanges(market="spot")
+symbols = maxi.cex.ticker.symbols(exchange="binance", market="spot")
 
-    ticker = maxi.cex.ticker.get(
-        exchange="binance",
-        symbol="BTC-USDT",
-        market="spot",
-        currency="USD",
-    )
-    ```
+ticker = maxi.cex.ticker.get(
+    exchange="binance",
+    symbol="BTC-USDT",
+    market="spot",
+    currency="USD",
+)
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            exchanges = await client.cex.ticker.exchanges(market="spot")
-            symbols = await client.cex.ticker.symbols(exchange="binance", market="spot")
-
-            ticker = await client.cex.ticker.get(
-                exchange="binance",
-                symbol="BTC-USDT",
-                market="spot",
-                currency="USD",
-            )
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        exchanges = await client.cex.ticker.exchanges(market="spot")
+        symbols = await client.cex.ticker.symbols(exchange="binance", market="spot")
+
+        ticker = await client.cex.ticker.get(
+            exchange="binance",
+            symbol="BTC-USDT",
+            market="spot",
+            currency="USD",
+        )
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/cex-token.md
+++ b/docs/cex-token.md
@@ -4,42 +4,46 @@ Token listing and delisting updates from centralized exchanges.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    data, next_request = maxi.cex.token.updates(
-        type="listed",
-        page=1,
-        limit=100,
-    )
+data, next_request = maxi.cex.token.updates(
+    type="listed",
+    page=1,
+    limit=100,
+)
 
-    more_data, _ = next_request()
-    ```
+more_data, _ = next_request()
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            data, next_request = await client.cex.token.updates(
-                type="listed",
-                page=1,
-                limit=100,
-            )
-
-            more_data, _ = await next_request()
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        data, next_request = await client.cex.token.updates(
+            type="listed",
+            page=1,
+            limit=100,
+        )
+
+        more_data, _ = await next_request()
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/cex-wallet-status.md
+++ b/docs/cex-wallet-status.md
@@ -4,36 +4,40 @@ Deposit and withdrawal availability for centralized exchange assets.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    exchanges = maxi.cex.wallet_status.exchanges()
-    assets = maxi.cex.wallet_status.assets(exchange="binance")
+exchanges = maxi.cex.wallet_status.exchanges()
+assets = maxi.cex.wallet_status.assets(exchange="binance")
 
-    status = maxi.cex.wallet_status(exchange="binance", asset="BTC")
-    ```
+status = maxi.cex.wallet_status(exchange="binance", asset="BTC")
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            exchanges = await client.cex.wallet_status.exchanges()
-            assets = await client.cex.wallet_status.assets(exchange="binance")
-
-            status = await client.cex.wallet_status(exchange="binance", asset="BTC")
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        exchanges = await client.cex.wallet_status.exchanges()
+        assets = await client.cex.wallet_status.assets(exchange="binance")
+
+        status = await client.cex.wallet_status(exchange="binance", asset="BTC")
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/forex.md
+++ b/docs/forex.md
@@ -4,32 +4,36 @@ Foreign exchange spot rates.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    symbols = maxi.forex.symbols()
-    data = maxi.forex(symbol="USD-KRW")
-    ```
+symbols = maxi.forex.symbols()
+data = maxi.forex(symbol="USD-KRW")
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            symbols = await client.forex.symbols()
-            data = await client.forex(symbol="USD-KRW")
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        symbols = await client.forex.symbols()
+        data = await client.forex(symbol="USD-KRW")
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/funding-rate.md
+++ b/docs/funding-rate.md
@@ -4,52 +4,56 @@ Historical and latest funding rates for perpetual futures.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    exchanges = maxi.funding_rate.exchanges()
-    symbols = maxi.funding_rate.symbols(exchange="binance")
+exchanges = maxi.funding_rate.exchanges()
+symbols = maxi.funding_rate.symbols(exchange="binance")
 
-    history, next_request = maxi.funding_rate.history(
-        exchange="binance",
-        symbol="BTC-USDT",
-        page=1,
-        limit=100,
-        sort="desc",
-    )
+history, next_request = maxi.funding_rate.history(
+    exchange="binance",
+    symbol="BTC-USDT",
+    page=1,
+    limit=100,
+    sort="desc",
+)
 
-    latest = maxi.funding_rate.latest(exchange="binance", symbol="BTC-USDT")
-    ```
+latest = maxi.funding_rate.latest(exchange="binance", symbol="BTC-USDT")
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            exchanges = await client.funding_rate.exchanges()
-            symbols = await client.funding_rate.symbols(exchange="binance")
-
-            history, next_request = await client.funding_rate.history(
-                exchange="binance",
-                symbol="BTC-USDT",
-                page=1,
-                limit=100,
-                sort="desc",
-            )
-
-            latest = await client.funding_rate.latest(exchange="binance", symbol="BTC-USDT")
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        exchanges = await client.funding_rate.exchanges()
+        symbols = await client.funding_rate.symbols(exchange="binance")
+
+        history, next_request = await client.funding_rate.history(
+            exchange="binance",
+            symbol="BTC-USDT",
+            page=1,
+            limit=100,
+            sort="desc",
+        )
+
+        latest = await client.funding_rate.latest(exchange="binance", symbol="BTC-USDT")
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/index-price.md
+++ b/docs/index-price.md
@@ -4,40 +4,44 @@ Historical index price time series for a single asset.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    data = maxi.index_price(
-        asset="BTC",
-        from_="now - 1 month",
-        to="now",
-        interval="5m",
-    )
-    ```
+data = maxi.index_price(
+    asset="BTC",
+    from_="now - 1 month",
+    to="now",
+    interval="5m",
+)
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            data = await client.index_price(
-                asset="BTC",
-                from_="now - 1 month",
-                to="now",
-                interval="5m",
-            )
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        data = await client.index_price(
+            asset="BTC",
+            from_="now - 1 month",
+            to="now",
+            interval="5m",
+        )
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/liquidation.md
+++ b/docs/liquidation.md
@@ -4,74 +4,78 @@ CEX futures liquidation data: recent events, firehose feed, heatmaps, maps, and 
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    # Recent liquidation events for a single futures symbol
-    events = maxi.liquidation(exchange="binance", symbol="BTC-USDT", limit=100)
+# Recent liquidation events for a single futures symbol
+events = maxi.liquidation(exchange="binance", symbol="BTC-USDT", limit=100)
 
-    # Firehose: most recent events across every symbol
-    feed = maxi.liquidation.feed(limit=100)
+# Firehose: most recent events across every symbol
+feed = maxi.liquidation.feed(limit=100)
 
-    # Token x exchange liquidation heatmap over a rolling window
-    heatmap = maxi.liquidation.heatmap(window="1h", topN=10)
+# Token x exchange liquidation heatmap over a rolling window
+heatmap = maxi.liquidation.heatmap(window="1h", topN=10)
 
-    # Liquidation KPI stats over a rolling window
-    stats = maxi.liquidation.stats(window="1h")
+# Liquidation KPI stats over a rolling window
+stats = maxi.liquidation.stats(window="1h")
 
-    # Coinglass-style liquidation map (price x leverage tier)
-    liq_map = maxi.liquidation.map(base="BTC", exchange="binance", quote="USDT")
+# Coinglass-style liquidation map (price x leverage tier)
+liq_map = maxi.liquidation.map(base="BTC", exchange="binance", quote="USDT")
 
-    # Bucketed long / short liquidation USD time series + price line
-    history = maxi.liquidation.symbol_history(
-        symbol="BTC",
-        quote="USDT",
-        exchange="binance",
-        interval="5m",
-        window="24h",
-    )
-    ```
+# Bucketed long / short liquidation USD time series + price line
+history = maxi.liquidation.symbol_history(
+    symbol="BTC",
+    quote="USDT",
+    exchange="binance",
+    interval="5m",
+    window="24h",
+)
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            # Recent liquidation events for a single futures symbol
-            events = await client.liquidation(exchange="binance", symbol="BTC-USDT", limit=100)
-
-            # Firehose: most recent events across every symbol
-            feed = await client.liquidation.feed(limit=100)
-
-            # Token x exchange liquidation heatmap over a rolling window
-            heatmap = await client.liquidation.heatmap(window="1h", topN=10)
-
-            # Liquidation KPI stats over a rolling window
-            stats = await client.liquidation.stats(window="1h")
-
-            # Coinglass-style liquidation map (price x leverage tier)
-            liq_map = await client.liquidation.map(base="BTC", exchange="binance", quote="USDT")
-
-            # Bucketed long / short liquidation USD time series + price line
-            history = await client.liquidation.symbol_history(
-                symbol="BTC",
-                quote="USDT",
-                exchange="binance",
-                interval="5m",
-                window="24h",
-            )
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        # Recent liquidation events for a single futures symbol
+        events = await client.liquidation(exchange="binance", symbol="BTC-USDT", limit=100)
+
+        # Firehose: most recent events across every symbol
+        feed = await client.liquidation.feed(limit=100)
+
+        # Token x exchange liquidation heatmap over a rolling window
+        heatmap = await client.liquidation.heatmap(window="1h", topN=10)
+
+        # Liquidation KPI stats over a rolling window
+        stats = await client.liquidation.stats(window="1h")
+
+        # Coinglass-style liquidation map (price x leverage tier)
+        liq_map = await client.liquidation.map(base="BTC", exchange="binance", quote="USDT")
+
+        # Bucketed long / short liquidation USD time series + price line
+        history = await client.liquidation.symbol_history(
+            symbol="BTC",
+            quote="USDT",
+            exchange="binance",
+            interval="5m",
+            window="24h",
+        )
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/margin-borrow.md
+++ b/docs/margin-borrow.md
@@ -4,30 +4,34 @@ Margin borrow data for a single asset.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    data = maxi.margin_borrow(asset="BTC")
-    ```
+data = maxi.margin_borrow(asset="BTC")
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            data = await client.margin_borrow(asset="BTC")
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        data = await client.margin_borrow(asset="BTC")
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ::: datamaxi.resources.MarginBorrow
     options:

--- a/docs/naver-trend.md
+++ b/docs/naver-trend.md
@@ -4,32 +4,36 @@ Search trend data for South Korea via Naver.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Naver
+```python
+from datamaxi import Naver
 
-    naver = Naver(api_key="YOUR_API_KEY")
+naver = Naver(api_key="YOUR_API_KEY")
 
-    symbols = naver.symbols()
-    trend = naver.trend(symbol="BTC")
-    ```
+symbols = naver.symbols()
+trend = naver.trend(symbol="BTC")
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncNaver
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncNaver(api_key="YOUR_API_KEY") as naver:
-            symbols = await naver.symbols()
-            trend = await naver.trend(symbol="BTC")
+```python
+import asyncio
+from datamaxi.aio import AsyncNaver
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncNaver(api_key="YOUR_API_KEY") as naver:
+        symbols = await naver.symbols()
+        trend = await naver.trend(symbol="BTC")
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/open-interest.md
+++ b/docs/open-interest.md
@@ -4,72 +4,76 @@ CEX futures Open Interest: latest snapshots, reporting pairs, the token x exchan
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    # Latest OI snapshot for a single futures symbol
-    snapshot = maxi.open_interest(exchange="binance", symbol="BTC-USDT")
+# Latest OI snapshot for a single futures symbol
+snapshot = maxi.open_interest(exchange="binance", symbol="BTC-USDT")
 
-    # List all (exchange, symbol) pairs currently reporting OI
-    pairs = maxi.open_interest.list(exchange="binance")
+# List all (exchange, symbol) pairs currently reporting OI
+pairs = maxi.open_interest.list(exchange="binance")
 
-    # Paginated token x exchange OI matrix
-    overview = maxi.open_interest.overview(
-        page=1,
-        limit=20,
-        key="binance",
-        sort="desc",
-    )
+# Paginated token x exchange OI matrix
+overview = maxi.open_interest.overview(
+    page=1,
+    limit=20,
+    key="binance",
+    sort="desc",
+)
 
-    # Top-line OI aggregates (total USD, top tokens, top exchanges)
-    summary = maxi.open_interest.summary(topN=10)
+# Top-line OI aggregates (total USD, top tokens, top exchanges)
+summary = maxi.open_interest.summary(topN=10)
 
-    # Per-exchange aggregated OI history for a single token
-    history = maxi.open_interest.history_aggregated(
-        token_id="bitcoin",
-        interval="1h",
-    )
-    ```
+# Per-exchange aggregated OI history for a single token
+history = maxi.open_interest.history_aggregated(
+    token_id="bitcoin",
+    interval="1h",
+)
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            # Latest OI snapshot for a single futures symbol
-            snapshot = await client.open_interest(exchange="binance", symbol="BTC-USDT")
-
-            # List all (exchange, symbol) pairs currently reporting OI
-            pairs = await client.open_interest.list(exchange="binance")
-
-            # Paginated token x exchange OI matrix
-            overview = await client.open_interest.overview(
-                page=1,
-                limit=20,
-                key="binance",
-                sort="desc",
-            )
-
-            # Top-line OI aggregates (total USD, top tokens, top exchanges)
-            summary = await client.open_interest.summary(topN=10)
-
-            # Per-exchange aggregated OI history for a single token
-            history = await client.open_interest.history_aggregated(
-                token_id="bitcoin",
-                interval="1h",
-            )
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        # Latest OI snapshot for a single futures symbol
+        snapshot = await client.open_interest(exchange="binance", symbol="BTC-USDT")
+
+        # List all (exchange, symbol) pairs currently reporting OI
+        pairs = await client.open_interest.list(exchange="binance")
+
+        # Paginated token x exchange OI matrix
+        overview = await client.open_interest.overview(
+            page=1,
+            limit=20,
+            key="binance",
+            sort="desc",
+        )
+
+        # Top-line OI aggregates (total USD, top tokens, top exchanges)
+        summary = await client.open_interest.summary(topN=10)
+
+        # Per-exchange aggregated OI history for a single token
+        history = await client.open_interest.history_aggregated(
+            token_id="bitcoin",
+            interval="1h",
+        )
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/premium.md
+++ b/docs/premium.md
@@ -4,52 +4,56 @@ Cross-exchange premium data for arbitrage and market dislocation analysis.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Datamaxi
+```python
+from datamaxi import Datamaxi
 
-    maxi = Datamaxi(api_key="YOUR_API_KEY")
+maxi = Datamaxi(api_key="YOUR_API_KEY")
 
-    exchanges = maxi.premium.exchanges()
+exchanges = maxi.premium.exchanges()
 
-    data = maxi.premium(
-        source_exchange="binance",
-        target_exchange="upbit",
-        asset="BTC",
-        source_market="spot",
-        target_market="spot",
-        sort="desc",
-        key="pdp",
-        limit=100,
-    )
-    ```
+data = maxi.premium(
+    source_exchange="binance",
+    target_exchange="upbit",
+    asset="BTC",
+    source_market="spot",
+    target_market="spot",
+    sort="desc",
+    key="pdp",
+    limit=100,
+)
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncDatamaxi
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
-            exchanges = await client.premium.exchanges()
-
-            data = await client.premium(
-                source_exchange="binance",
-                target_exchange="upbit",
-                asset="BTC",
-                source_market="spot",
-                target_market="spot",
-                sort="desc",
-                key="pdp",
-                limit=100,
-            )
+```python
+import asyncio
+from datamaxi.aio import AsyncDatamaxi
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncDatamaxi(api_key="YOUR_API_KEY") as client:
+        exchanges = await client.premium.exchanges()
+
+        data = await client.premium(
+            source_exchange="binance",
+            target_exchange="upbit",
+            asset="BTC",
+            source_market="spot",
+            target_market="spot",
+            sort="desc",
+            key="pdp",
+            limit=100,
+        )
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -4,38 +4,42 @@ Telegram channel metadata and message history.
 
 ## Usage
 
-=== "Sync"
+<details markdown="1"><summary>Sync</summary>
 
-    ```python
-    from datamaxi import Telegram
+```python
+from datamaxi import Telegram
 
-    telegram = Telegram(api_key="YOUR_API_KEY")
+telegram = Telegram(api_key="YOUR_API_KEY")
 
-    channels, _ = telegram.channels(category="korean", limit=50)
-    messages, next_request = telegram.messages(channel_name="yunlog_announcement", limit=50)
+channels, _ = telegram.channels(category="korean", limit=50)
+messages, next_request = telegram.messages(channel_name="yunlog_announcement", limit=50)
 
-    more_messages, _ = next_request()
-    ```
+more_messages, _ = next_request()
+```
 
-=== "Async"
+</details>
 
-    ```python
-    import asyncio
-    from datamaxi.aio import AsyncTelegram
+<details markdown="1"><summary>Async</summary>
 
-
-    async def main():
-        async with AsyncTelegram(api_key="YOUR_API_KEY") as telegram:
-            channels, _ = await telegram.channels(category="korean", limit=50)
-            messages, next_request = await telegram.messages(
-                channel_name="yunlog_announcement", limit=50
-            )
-
-            more_messages, _ = await next_request()
+```python
+import asyncio
+from datamaxi.aio import AsyncTelegram
 
 
-    asyncio.run(main())
-    ```
+async def main():
+    async with AsyncTelegram(api_key="YOUR_API_KEY") as telegram:
+        channels, _ = await telegram.channels(category="korean", limit=50)
+        messages, next_request = await telegram.messages(
+            channel_name="yunlog_announcement", limit=50
+        )
+
+        more_messages, _ = await next_request()
+
+
+asyncio.run(main())
+```
+
+</details>
 
 ## Notes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ plugins:
 markdown_extensions:
   - toc:
       permalink: true
+  - md_in_html
   - codehilite
   - pymdownx.highlight:
       use_pygments: true


### PR DESCRIPTION
Closes #166

## What
Replace Material-for-MkDocs `=== "Sync"/"Async"` content-tabs with GitHub-native collapsible `<details markdown="1"><summary>Sync|Async</summary>` blocks in the README and 16 docs pages. Enable `md_in_html` in `mkdocs.yml` so fenced code inside `<details>` still highlights on the ReadTheDocs site.

## Why
`=== "Sync"` renders as literal text on GitHub and the 4-space-indented fenced code beneath it loses syntax highlighting. `<details>` renders correctly on both GitHub and MkDocs.

## Changed
- 34 tab blocks -> `<details>` across README.md + 16 docs/*.md (docs/index.md is a symlink to README, so it's covered automatically -> 36 blocks total).
- mkdocs.yml: added `- md_in_html` to `markdown_extensions`. Left `pymdownx.tabbed` in place (removal not in scope; harmless once unused).
- Code content preserved verbatim; only the tab wrapper syntax changed (de-indented 4 spaces to sit at column 0 inside `<details>`).

## Verification
- grep: zero `=== "Sync"/"Async"` remain.
- Structural check script: all 36 `<details>` have `markdown="1"`, a blank line after `</summary>`, and a blank line before `</details>` (0 problems).
- `mkdocs build --strict`: not run (mkdocs not installed locally; per task, no global tooling installed).