### PR TITLE
chore: regen WS generated files (drop stale param_note caveats)

### DIFF
--- a/datamaxi/_ws_endpoints.py
+++ b/datamaxi/_ws_endpoints.py
@@ -34,7 +34,6 @@ WS_CHANNELS = {
         "param": "SYMBOL",
         "subscribe": True,
         "unsubscribe": True,
-        "param_note": "fx pair e.g. USD-KRW, no exchange",
     },
     "/funding-rate": {
         "plan": "basic",
@@ -43,7 +42,6 @@ WS_CHANNELS = {
         "param": "SYMBOL@exchange",
         "subscribe": True,
         "unsubscribe": True,
-        "param_note": "UPPER symbol + lower exchange; verified live (handler.go doc comment is wrong — Bisonai/datamaxi-backend#7926)",
     },
     "/liquidation": {
         "plan": "basic",


### PR DESCRIPTION
## Summary
Regenerates `datamaxi/_ws_endpoints.py` + `datamaxi/_ws_models.py` from datamaxi-codegen now that it reads the backend's AsyncAPI spec ([codegen #53](https://github.com/Bisonai/datamaxi-codegen/pull/53)) instead of the route-table regex + param overrides.

Sole change: the two obsolete `param_note` caveats are dropped —
- `forex`: `"fx pair e.g. USD-KRW, no exchange"`
- `funding-rate`: the "code/doc disagree" note (the backend doc-comment ambiguity was fixed in [datamaxi-backend #7929](https://github.com/Bisonai/datamaxi-backend/issues/7926)).

`_ws_models.py` is byte-unchanged. Nothing in the SDK reads `param_note`, so this is purely keeping the committed generated files in sync with the generator.

## Verification
- `git diff` = 2 deletions in `_ws_endpoints.py`, nothing else.
- `pytest tests/test_ws.py tests/test_async.py`: **19 passed**.

## Context
This is the trivial downstream sync noted in codegen #53. A WS drift-guard (`check-ws-python`, codegen #47) would automate catching this going forward.

## Known failures
None.