### PR TITLE
Sync generated _endpoints.py with backend spec

### DIFF
--- a/datamaxi/_responses.py
+++ b/datamaxi/_responses.py
@@ -245,8 +245,6 @@ class FundingRateLatestResponse:
     i: int = 0
     # Specifies the token id
     id: str = ""
-    # Specifies the processed at
-    p: int = 0
     # Specifies the quote
     q: str = ""
     # Specifies the symbol
@@ -261,7 +259,6 @@ class FundingRateLatestResponse:
             f=data.get("f", 0.0),
             i=data.get("i", 0),
             id=data.get("id", ""),
-            p=data.get("p", 0),
             q=data.get("q", ""),
             s=data.get("s", ""),
         )


### PR DESCRIPTION
Automated registry sync from **datamaxi-codegen**.

The committed `datamaxi/_endpoints.py` had drifted from the current
`Bisonai/datamaxi-backend` OpenAPI spec. This PR regenerates it via
`make update-python`.

Triggering codegen run:
https://github.com/Bisonai/datamaxi-codegen/actions/runs/28737515272

Do not edit `_endpoints.py` by hand — it is generated. Re-run the
codegen workflow to refresh.