### PR TITLE
test(ws): live ticker data assertion on high-traffic channel (Closes #181)

### DIFF
--- a/tests/test_ws_live.py
+++ b/tests/test_ws_live.py
@@ -28,6 +28,9 @@ pytestmark = [
 
 # Sporadic channels may be silent for long stretches; a quiet window is a pass.
 _QUIET_TIMEOUT = 10.0
+# High-traffic channels emit continuously, so a quiet window is a FAIL. ticker
+# ticks roughly every ~10s in practice; give headroom so one slow tick can't flake.
+_DATA_TIMEOUT = 30.0
 
 
 def _run(coro):
@@ -76,3 +79,19 @@ def test_ws_announcement_subscribe_tolerates_quiet_window():
         pytest.skip(f"/announcement/listing rejected (needs Pro+ tier): {exc!r}")
     if msg is not None:
         assert isinstance(msg, dict)
+
+
+def test_ws_ticker_yields_live_data():
+    # /ticker (spot) is high-traffic: it emits continuously, so a quiet window is
+    # a FAIL, not a pass. Unlike the sporadic channels above, this proves the SDK
+    # decodes and yields a real payload end-to-end — connect + auth + SUBSCRIBE +
+    # an actual well-formed data message for BTC-USDT@binance within the timeout.
+    async def run():
+        async with AsyncDatamaxiWS(api_key=API_KEY, base_url=BASE_URL) as ws:
+            stream = await ws.ticker.subscribe("BTC-USDT@binance", market="spot")
+            return await asyncio.wait_for(stream.__anext__(), _DATA_TIMEOUT)
+
+    msg = _run(run())
+    assert isinstance(msg, dict)
+    assert msg["s"] == "BTC-USDT"
+    assert "p" in msg

--- a/tests/test_ws_live.py
+++ b/tests/test_ws_live.py
@@ -107,6 +107,22 @@ def test_ws_ticker_yields_live_data():
     assert "p" in msg
 
 
+def test_ws_ticker_futures_yields_live_data():
+    # /ticker/futures is the futures-market sibling of the spot test above: also
+    # high-traffic, so a quiet window is a FAIL. Assert `m == "futures"` too, to
+    # prove the futures path (not spot) is what's exercised end-to-end.
+    async def run():
+        async with AsyncDatamaxiWS(api_key=API_KEY, base_url=BASE_URL) as ws:
+            stream = await ws.ticker.subscribe("BTC-USDT@binance", market="futures")
+            return await asyncio.wait_for(stream.__anext__(), _DATA_TIMEOUT)
+
+    msg = _run(run())
+    assert isinstance(msg, dict)
+    assert msg["s"] == "BTC-USDT"
+    assert "p" in msg
+    assert msg["m"] == "futures"
+
+
 def test_ws_premium_yields_live_data():
     # /premium (cross-exchange premium) is high-traffic: crypto premium trades
     # 24/7, so — like ticker — a quiet window is a FAIL. Proves the SDK decodes

--- a/tests/test_ws_live.py
+++ b/tests/test_ws_live.py
@@ -1,12 +1,19 @@
-"""Keyed live/integration lane for sporadic WS channels.
+"""Keyed live/integration lane for the real DataMaxi+ WS API.
 
 The offline `test_ws.py` covers the protocol against a local server. These
-tests hit the real DataMaxi+ WS API for the two event-driven channels that
-only got ack-level live checks — `/liquidation` (subscribe-only) and
-`/announcement/listing` (Pro+). Both are sporadic, so a quiet window (no event
-in the timeout) is a PASS: the value is that connect + auth + SUBSCRIBE succeed
-without raising. Opt-in and deselected from the keyless CI lane via the
-`integration` marker; needs DATAMAXI_API_KEY. Skipped when `websockets` absent.
+tests hit prod. Two kinds of channel:
+
+- Sporadic (event-driven): `/liquidation`, `/announcement/listing`,
+  `/funding-rate`, `/open-interest`, and `/forex` (weekends/off-hours). A quiet
+  window (no message in the timeout) is a PASS — the value is that connect +
+  auth + SUBSCRIBE succeed without raising; when a message does arrive its shape
+  is still checked.
+- High-traffic (continuous): `/ticker` and `/premium`. These emit non-stop, so
+  a quiet window is a FAIL — the test asserts a real, well-formed data payload
+  actually arrives, proving the SDK decodes and yields end-to-end.
+
+Opt-in and deselected from the keyless CI lane via the `integration` marker;
+needs DATAMAXI_API_KEY. Skipped when `websockets` absent.
 """
 
 import asyncio
@@ -31,6 +38,9 @@ _QUIET_TIMEOUT = 10.0
 # High-traffic channels emit continuously, so a quiet window is a FAIL. ticker
 # ticks roughly every ~10s in practice; give headroom so one slow tick can't flake.
 _DATA_TIMEOUT = 30.0
+# /forex is quiet-tolerant but its first tick can lag (~14s observed); wait a bit
+# longer than _QUIET_TIMEOUT so an arriving tick gets shape-checked, not skipped.
+_FOREX_TIMEOUT = 20.0
 
 
 def _run(coro):
@@ -95,3 +105,79 @@ def test_ws_ticker_yields_live_data():
     assert isinstance(msg, dict)
     assert msg["s"] == "BTC-USDT"
     assert "p" in msg
+
+
+def test_ws_premium_yields_live_data():
+    # /premium (cross-exchange premium) is high-traffic: crypto premium trades
+    # 24/7, so — like ticker — a quiet window is a FAIL. Proves the SDK decodes
+    # and yields a real premium payload end-to-end. The `premium` value itself
+    # can be null, so assert on stable identity fields, not the value.
+    key = "binance:upbit:bitcoin:USDT:KRW:spot:spot"
+
+    async def run():
+        async with AsyncDatamaxiWS(api_key=API_KEY, base_url=BASE_URL) as ws:
+            stream = await ws.premium.subscribe(key)
+            return await asyncio.wait_for(stream.__anext__(), _DATA_TIMEOUT)
+
+    msg = _run(run())
+    assert isinstance(msg, dict)
+    assert msg["key"] == key
+    assert "premium" in msg
+
+
+def test_ws_forex_tolerates_quiet_window():
+    # /forex is continuous during FX market hours but the first tick can lag
+    # (~14s observed) and FX spot does not trade weekends — so a quiet window is
+    # a legitimate PASS (like the sporadic channels). When a tick does arrive,
+    # validate its shape.
+    async def run():
+        async with AsyncDatamaxiWS(api_key=API_KEY, base_url=BASE_URL) as ws:
+            stream = await ws.forex.subscribe("USD-KRW")
+            try:
+                return await asyncio.wait_for(stream.__anext__(), _FOREX_TIMEOUT)
+            except asyncio.TimeoutError:
+                # quiet window (off-hours/weekend): subscribed fine, just no tick
+                return None
+
+    msg = _run(run())
+    if msg is not None:
+        assert isinstance(msg, dict)
+        assert msg["s"] == "USD-KRW"
+        assert "r" in msg
+
+
+def test_ws_funding_rate_tolerates_quiet_window():
+    # /funding-rate pushes on-change/snapshot — sporadic (0 msgs in a 20s probe),
+    # so a quiet window is a PASS. Shape wasn't observable live; when a message
+    # does arrive, assert only that it's a non-empty data dict (acks are already
+    # filtered by the client's reader).
+    async def run():
+        async with AsyncDatamaxiWS(api_key=API_KEY, base_url=BASE_URL) as ws:
+            stream = await ws.funding_rate.subscribe("BTC-USDT@binance")
+            try:
+                return await asyncio.wait_for(stream.__anext__(), _QUIET_TIMEOUT)
+            except asyncio.TimeoutError:
+                return None
+
+    msg = _run(run())
+    if msg is not None:
+        assert isinstance(msg, dict)
+        assert msg
+
+
+def test_ws_open_interest_tolerates_quiet_window():
+    # /open-interest is sporadic (0 msgs in a 20s probe), so a quiet window is a
+    # PASS. Shape wasn't observable live; when a message does arrive, assert only
+    # that it's a non-empty data dict (acks are already filtered by the reader).
+    async def run():
+        async with AsyncDatamaxiWS(api_key=API_KEY, base_url=BASE_URL) as ws:
+            stream = await ws.open_interest.subscribe("BTC-USDT@binance")
+            try:
+                return await asyncio.wait_for(stream.__anext__(), _QUIET_TIMEOUT)
+            except asyncio.TimeoutError:
+                return None
+
+    msg = _run(run())
+    if msg is not None:
+        assert isinstance(msg, dict)
+        assert msg


### PR DESCRIPTION
Closes #181

## Summary
The live WS lane only covered **sporadic** channels (`/liquidation`, `/announcement/listing`) where a quiet window (no event before timeout) is a **pass** — that verifies connect + auth + SUBSCRIBE but never proves the SDK decodes and yields a real payload. This PR adds coverage across more channels, choosing the test type per channel's real cadence (probed live):

**High-traffic → HARD data-assertion (silence = FAIL):**
- `ticker` spot (`BTC-USDT@binance`) — asserts `msg["s"]=="BTC-USDT"`, `"p" in msg` within 30s.
- `ticker` futures (`BTC-USDT@binance`, `market="futures"`) — same, plus `msg["m"]=="futures"` to prove the futures path (not spot) is exercised.
- `premium` (`binance:upbit:bitcoin:USDT:KRW:spot:spot`, 24/7) — asserts `msg["key"]==...`, `"premium" in msg` within 30s (the `premium` value is nullable, so identity fields are asserted, not the value).

**Sporadic → quiet-window TOLERANT (silence = PASS) + shape-check-if-present:**
- `forex` (`USD-KRW`) — 20s bound (first tick can lag ~14s; FX spot is quiet on weekends/off-hours). If a tick arrives: `msg["s"]=="USD-KRW"`, `"r" in msg`.
- `funding_rate` (`BTC-USDT@binance`) — on-change/snapshot, sporadic. If a msg arrives: non-empty data dict (shape not observable live).
- `open_interest` (`BTC-USDT@binance`) — sporadic. Same minimal shape check.

Quiet-tolerant tests mirror the existing `test_ws_liquidation_...` structure (`TimeoutError` → PASS). Acks are filtered by the client reader, so the first yielded message is always a real payload. Additive: new test fns + `_DATA_TIMEOUT`/`_FOREX_TIMEOUT` constants + widened module docstring; existing tests untouched. All under the `integration` marker (needs `DATAMAXI_API_KEY`), deselected from the keyless lane, consistent with the non-blocking (`continue-on-error`) live lane.

## Test plan
- `DATAMAXI_API_KEY=... pytest tests/test_ws_live.py -v -m integration` → **8 passed** (ticker spot/futures + premium receive real data; forex/funding/OI pass via quiet window or shape-check).
- `pytest tests/ -m "not integration"` → 226 passed, all live tests deselected (115 deselected).
- `black` + `flake8` clean.