### PR TITLE
Mount Telegram and Naver as sub-resources on Datamaxi / AsyncDatamaxi

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,6 @@ The package ships these clients, all configured the same way (see
 | Client            | Import                                        | Purpose                                                    |
 | ----------------- | --------------------------------------------- | ---------------------------------------------------------- |
 | `Datamaxi`        | `from datamaxi import Datamaxi`               | Synchronous client for all REST data, incl. `maxi.telegram` / `maxi.naver`. |
-| `Telegram`        | `from datamaxi import Telegram`               | Standalone Telegram client (also mounted as `maxi.telegram`). |
-| `Naver`           | `from datamaxi import Naver`                  | Standalone Naver search-trend client (also mounted as `maxi.naver`). |
 | `AsyncDatamaxi`   | `from datamaxi.aio import AsyncDatamaxi`      | Async twin of `Datamaxi` (needs the `[async]` extra).      |
 | `AsyncDatamaxiWS` | `from datamaxi.aio.ws import AsyncDatamaxiWS` | Async WebSocket streaming (needs the `[ws]` extra).        |
 
@@ -500,9 +498,6 @@ Off-exchange signals: Telegram channels and Naver search trends.
 Fetch Telegram channel messages and metadata.
 
 ```python
-# Telegram is mounted on the client as `maxi.telegram`
-# (a standalone `from datamaxi import Telegram` client also works).
-
 # Fetch channels
 data, next_request = maxi.telegram.channels(
     page=1,                  # Optional: page number
@@ -528,9 +523,6 @@ data, next_request = maxi.telegram.messages(
 Fetch Naver search trend data (South Korea).
 
 ```python
-# Naver is mounted on the client as `maxi.naver`
-# (a standalone `from datamaxi import Naver` client also works).
-
 # Get supported symbols
 symbols = maxi.naver.symbols()
 

--- a/README.md
+++ b/README.md
@@ -751,9 +751,7 @@ asyncio.run(main())
 Use `AsyncDatamaxi` as an async context manager (shown above) or call
 `await client.aclose()` yourself. Paginated endpoints return an async
 `next_request` — `await` it too
-(`data, next_request = await client.cex.announcement(...)`). Telegram and Naver
-are mounted as `client.telegram` / `client.naver`; standalone
-`AsyncTelegram` / `AsyncNaver` clients remain available too.
+(`data, next_request = await client.cex.announcement(...)`).
 
 Every endpoint in the [REST API Reference](#rest-api-reference) works the same
 under the async client — see the [docs](https://datamaxi.readthedocs.io/) where

--- a/README.md
+++ b/README.md
@@ -100,13 +100,16 @@ the others.
 <details markdown="1"><summary>Sync</summary>
 
 ```python
-from datamaxi import Datamaxi, Telegram, Naver
+from datamaxi import Datamaxi
 
-# Clients read DATAMAXI_API_KEY from the environment automatically.
-# Alternatively, pass api_key="your_api_key" explicitly to each client.
+# The client reads DATAMAXI_API_KEY from the environment automatically.
+# Alternatively, pass api_key="your_api_key" explicitly.
 maxi = Datamaxi()
-telegram = Telegram()
-naver = Naver()
+
+# Telegram and Naver are mounted as `maxi.telegram` / `maxi.naver`
+# (standalone `Telegram` / `Naver` clients remain available too).
+channels, _ = maxi.telegram.channels()
+trend = maxi.naver.trend(symbol="BTC")
 
 # Fetch CEX candle data (returns pandas DataFrame)
 df = maxi.cex.candle(
@@ -188,14 +191,16 @@ The package ships these clients, all configured the same way (see
 
 | Client            | Import                                        | Purpose                                                    |
 | ----------------- | --------------------------------------------- | ---------------------------------------------------------- |
-| `Datamaxi`        | `from datamaxi import Datamaxi`               | Synchronous client for all crypto REST data.               |
-| `Telegram`        | `from datamaxi import Telegram`               | Telegram channel messages and metadata.                    |
-| `Naver`           | `from datamaxi import Naver`                  | Naver search-trend data (South Korea).                     |
+| `Datamaxi`        | `from datamaxi import Datamaxi`               | Synchronous client for all REST data, incl. `maxi.telegram` / `maxi.naver`. |
+| `Telegram`        | `from datamaxi import Telegram`               | Standalone Telegram client (also mounted as `maxi.telegram`). |
+| `Naver`           | `from datamaxi import Naver`                  | Standalone Naver search-trend client (also mounted as `maxi.naver`). |
 | `AsyncDatamaxi`   | `from datamaxi.aio import AsyncDatamaxi`      | Async twin of `Datamaxi` (needs the `[async]` extra).      |
 | `AsyncDatamaxiWS` | `from datamaxi.aio.ws import AsyncDatamaxiWS` | Async WebSocket streaming (needs the `[ws]` extra).        |
 
-`AsyncTelegram` and `AsyncNaver` are the async twins of `Telegram` / `Naver`,
-also imported from `datamaxi.aio`.
+Telegram and Naver are mounted on `Datamaxi` / `AsyncDatamaxi` (`maxi.telegram`,
+`maxi.naver`) so they reuse the client's shared session. The standalone
+`Telegram` / `Naver` (and their async twins `AsyncTelegram` / `AsyncNaver`,
+imported from `datamaxi.aio`) remain available for independent use.
 
 ## REST API Reference
 
@@ -495,12 +500,11 @@ Off-exchange signals: Telegram channels and Naver search trends.
 Fetch Telegram channel messages and metadata.
 
 ```python
-# Initialize Telegram client
-from datamaxi import Telegram
-telegram = Telegram(api_key=api_key)
+# Telegram is mounted on the client as `maxi.telegram`
+# (a standalone `from datamaxi import Telegram` client also works).
 
 # Fetch channels
-data, next_request = telegram.channels(
+data, next_request = maxi.telegram.channels(
     page=1,                  # Optional: page number
     limit=1000,              # Optional: items per page
     category=None,           # Optional: filter by category
@@ -509,7 +513,7 @@ data, next_request = telegram.channels(
 )
 
 # Fetch messages
-data, next_request = telegram.messages(
+data, next_request = maxi.telegram.messages(
     channel_name=None,       # Optional: filter by channel
     page=1,                  # Optional: page number
     limit=1000,              # Optional: items per page
@@ -524,15 +528,14 @@ data, next_request = telegram.messages(
 Fetch Naver search trend data (South Korea).
 
 ```python
-# Initialize Naver client
-from datamaxi import Naver
-naver = Naver(api_key=api_key)
+# Naver is mounted on the client as `maxi.naver`
+# (a standalone `from datamaxi import Naver` client also works).
 
 # Get supported symbols
-symbols = naver.symbols()
+symbols = maxi.naver.symbols()
 
 # Fetch trend data
-data = naver.trend(
+data = maxi.naver.trend(
     symbol="BTC",            # Required: symbol to search
     pandas=True              # Optional: return DataFrame or list
 )
@@ -757,7 +760,8 @@ Use `AsyncDatamaxi` as an async context manager (shown above) or call
 `await client.aclose()` yourself. Paginated endpoints return an async
 `next_request` — `await` it too
 (`data, next_request = await client.cex.announcement(...)`). Telegram and Naver
-have standalone `AsyncTelegram` / `AsyncNaver` clients.
+are mounted as `client.telegram` / `client.naver`; standalone
+`AsyncTelegram` / `AsyncNaver` clients remain available too.
 
 Every endpoint in the [REST API Reference](#rest-api-reference) works the same
 under the async client — see the [docs](https://datamaxi.readthedocs.io/) where

--- a/datamaxi/aio/__init__.py
+++ b/datamaxi/aio/__init__.py
@@ -16,7 +16,9 @@ Usage::
 
 Mirrors the full sync surface (``cex.*``, ``funding_rate``, ``forex``,
 ``premium``, ``liquidation``, ``open_interest``, ``margin_borrow``,
-``index_price``, plus standalone ``AsyncTelegram`` / ``AsyncNaver``). Reuses
+``index_price``, ``telegram``, ``naver``). The standalone
+``AsyncTelegram`` / ``AsyncNaver`` classes stay exported for back-compat.
+Reuses
 the sync client's endpoint resolution and error handling (``datamaxi._dispatch``)
 and the shared DataFrame / ResponseMeta helpers, so the two clients can't drift
 on request building or error semantics.
@@ -68,6 +70,12 @@ class AsyncDatamaxi:
         self.open_interest = AsyncOpenInterest(api)
         self.margin_borrow = AsyncMarginBorrow(api)
         self.index_price = AsyncIndexPrice(api)
+        # Non-crypto data types. Mounted here so they reuse the one shared
+        # session like every other sub-resource; the standalone
+        # ``AsyncTelegram`` / ``AsyncNaver`` classes stay exported for
+        # back-compat (see #184).
+        self.telegram = AsyncTelegram(api=api)
+        self.naver = AsyncNaver(api=api)
 
     async def aclose(self):
         await self._api.aclose()

--- a/datamaxi/aio/__init__.py
+++ b/datamaxi/aio/__init__.py
@@ -70,10 +70,6 @@ class AsyncDatamaxi:
         self.open_interest = AsyncOpenInterest(api)
         self.margin_borrow = AsyncMarginBorrow(api)
         self.index_price = AsyncIndexPrice(api)
-        # Non-crypto data types. Mounted here so they reuse the one shared
-        # session like every other sub-resource; the standalone
-        # ``AsyncTelegram`` / ``AsyncNaver`` classes stay exported for
-        # back-compat (see #184).
         self.telegram = AsyncTelegram(api=api)
         self.naver = AsyncNaver(api=api)
 

--- a/datamaxi/aio/naver.py
+++ b/datamaxi/aio/naver.py
@@ -20,10 +20,12 @@ if TYPE_CHECKING:
 class AsyncNaver(AsyncResource):
     """Client to fetch Naver trend data from DataMaxi+ API (async)."""
 
-    def __init__(self, api_key=None, **kwargs: Any):
-        if "base_url" not in kwargs:
-            kwargs["base_url"] = BASE_URL
-        super().__init__(AsyncAPI(api_key, **kwargs))
+    def __init__(self, api_key=None, api=None, **kwargs: Any):
+        if api is None:
+            if "base_url" not in kwargs:
+                kwargs["base_url"] = BASE_URL
+            api = AsyncAPI(api_key, **kwargs)
+        super().__init__(api)
 
     async def aclose(self):
         await self._api.aclose()

--- a/datamaxi/aio/telegram.py
+++ b/datamaxi/aio/telegram.py
@@ -17,10 +17,12 @@ from datamaxi.lib.constants import BASE_URL, SortOrder
 class AsyncTelegram(AsyncResource):
     """Client to fetch Telegram data from DataMaxi+ API (async)."""
 
-    def __init__(self, api_key=None, **kwargs: Any):
-        if "base_url" not in kwargs:
-            kwargs["base_url"] = BASE_URL
-        super().__init__(AsyncAPI(api_key, **kwargs))
+    def __init__(self, api_key=None, api=None, **kwargs: Any):
+        if api is None:
+            if "base_url" not in kwargs:
+                kwargs["base_url"] = BASE_URL
+            api = AsyncAPI(api_key, **kwargs)
+        super().__init__(api)
 
     async def aclose(self):
         await self._api.aclose()

--- a/datamaxi/naver/__init__.py
+++ b/datamaxi/naver/__init__.py
@@ -13,16 +13,19 @@ if TYPE_CHECKING:
 class Naver(Resource):
     """Client to fetch Naver trend data from DataMaxi+ API."""
 
-    def __init__(self, api_key=None, **kwargs: Any):
+    def __init__(self, api_key=None, api=None, **kwargs: Any):
         """Initialize the object.
 
         Args:
             api_key (str): The DataMaxi+ API key
+            api (API): Shared transport to reuse when mounted on
+                ``Datamaxi`` (``maxi.naver``); when omitted this builds its
+                own ``API`` for standalone use.
             **kwargs: Keyword arguments used by `datamaxi.api.API`.
         """
-        if "base_url" not in kwargs:
+        if api is None and "base_url" not in kwargs:
             kwargs["base_url"] = BASE_URL
-        super().__init__(api_key, **kwargs)
+        super().__init__(api_key, api=api, **kwargs)
 
     def symbols(self) -> List[str]:
         """Get Naver trend supported token symbols

--- a/datamaxi/resources/__init__.py
+++ b/datamaxi/resources/__init__.py
@@ -28,6 +28,8 @@ from datamaxi.resources.cex_token import (  # used in documentation # noqa:F401
 from datamaxi.resources.cex_symbol import (  # used in documentation # noqa:F401
     CexSymbol,
 )
+from datamaxi.telegram import Telegram
+from datamaxi.naver import Naver
 
 
 class Datamaxi:
@@ -67,6 +69,11 @@ class Datamaxi:
         self.open_interest = OpenInterest(api=api)
         self.margin_borrow = MarginBorrow(api=api)
         self.index_price = IndexPrice(api=api)
+        # Non-crypto data types. Mounted here so they reuse the one shared
+        # session like every other sub-resource; the standalone `Telegram` /
+        # `Naver` classes stay exported for back-compat (see #184).
+        self.telegram = Telegram(api=api)
+        self.naver = Naver(api=api)
 
     def close(self):
         self._api.close()

--- a/datamaxi/resources/__init__.py
+++ b/datamaxi/resources/__init__.py
@@ -69,9 +69,6 @@ class Datamaxi:
         self.open_interest = OpenInterest(api=api)
         self.margin_borrow = MarginBorrow(api=api)
         self.index_price = IndexPrice(api=api)
-        # Non-crypto data types. Mounted here so they reuse the one shared
-        # session like every other sub-resource; the standalone `Telegram` /
-        # `Naver` classes stay exported for back-compat (see #184).
         self.telegram = Telegram(api=api)
         self.naver = Naver(api=api)
 

--- a/datamaxi/telegram/__init__.py
+++ b/datamaxi/telegram/__init__.py
@@ -10,16 +10,19 @@ from datamaxi.lib.constants import BASE_URL, SortOrder
 class Telegram(Resource):
     """Client to fetch Telegram data from DataMaxi+ API."""
 
-    def __init__(self, api_key=None, **kwargs: Any):
+    def __init__(self, api_key=None, api=None, **kwargs: Any):
         """Initialize the object.
 
         Args:
             api_key (str): The DataMaxi+ API key
+            api (API): Shared transport to reuse when mounted on
+                ``Datamaxi`` (``maxi.telegram``); when omitted this builds
+                its own ``API`` for standalone use.
             **kwargs: Keyword arguments used by `datamaxi.api.API`.
         """
-        if "base_url" not in kwargs:
+        if api is None and "base_url" not in kwargs:
             kwargs["base_url"] = BASE_URL
-        super().__init__(api_key, **kwargs)
+        super().__init__(api_key, api=api, **kwargs)
 
     def channels(
         self,

--- a/tests/test_async_resources.py
+++ b/tests/test_async_resources.py
@@ -171,6 +171,30 @@ def test_async_telegram_pagination():
     assert _run(run()) == _CHANNELS
 
 
+def test_async_telegram_naver_mounted_reuse_shared_session():
+    c = _dm()
+    assert isinstance(c.telegram, AsyncTelegram)
+    assert isinstance(c.naver, AsyncNaver)
+    # Same shared AsyncAPI/transport as every other sub-resource.
+    assert c.telegram._api is c._api
+    assert c.naver._api is c._api
+    assert c.telegram._api is c.cex._api
+
+
+def test_async_mounted_telegram_and_naver_work():
+    async def run():
+        async with _dm() as c:
+            channels, _ = await c.telegram.channels()
+            messages, _ = await c.telegram.messages(channel_name="alpha")
+            trend = await c.naver.trend("BTC", pandas=False)
+            return channels, messages, trend
+
+    channels, messages, trend = _run(run())
+    assert channels == _CHANNELS
+    assert messages == _MESSAGES
+    assert trend == _TREND
+
+
 def test_async_funding_history_and_latest():
     async def run():
         async with _dm() as c:

--- a/tests/test_naver.py
+++ b/tests/test_naver.py
@@ -70,9 +70,6 @@ def test_naver_trend_server_error():
         _client().trend("BTC")
 
 
-# --- mounted sub-resource on Datamaxi (see #184) ---
-
-
 def test_naver_mounted_reuses_shared_session():
     maxi = Datamaxi(api_key="key", base_url=BASE_URL)
     assert isinstance(maxi.naver, Naver)

--- a/tests/test_naver.py
+++ b/tests/test_naver.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from urllib.parse import urlparse, parse_qs
 
-from datamaxi.naver import Naver
+from datamaxi import Datamaxi, Naver
 from datamaxi.error import ClientError, ServerError
 from tests.util import mock_http_response
 
@@ -68,3 +68,22 @@ def test_naver_trend_client_error():
 def test_naver_trend_server_error():
     with pytest.raises(ServerError):
         _client().trend("BTC")
+
+
+# --- mounted sub-resource on Datamaxi (see #184) ---
+
+
+def test_naver_mounted_reuses_shared_session():
+    maxi = Datamaxi(api_key="key", base_url=BASE_URL)
+    assert isinstance(maxi.naver, Naver)
+    # Same shared API/transport as every other sub-resource.
+    assert maxi.naver._api is maxi._api
+    assert maxi.naver._api is maxi.cex._api
+
+
+@mock_http_response(responses.GET, "/api/v1/naver-trend", _TREND)
+def test_naver_mounted_trend_works():
+    maxi = Datamaxi(api_key="key", base_url=BASE_URL)
+    df = maxi.naver.trend("BTC")
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -5,7 +5,7 @@ import responses
 import pytest
 from urllib.parse import urlparse, parse_qs
 
-from datamaxi.telegram import Telegram
+from datamaxi import Datamaxi, Telegram
 from datamaxi.error import ClientError, ServerError
 from tests.util import mock_http_response
 
@@ -101,3 +101,30 @@ def test_channels_client_error():
 def test_messages_server_error():
     with pytest.raises(ServerError):
         _client().messages(channel_name="alpha")
+
+
+# --- mounted sub-resource on Datamaxi (see #184) ---
+
+
+def test_telegram_mounted_reuses_shared_session():
+    maxi = Datamaxi(api_key="key", base_url=BASE_URL)
+    assert isinstance(maxi.telegram, Telegram)
+    # Same shared API/transport as every other sub-resource.
+    assert maxi.telegram._api is maxi._api
+    assert maxi.telegram._api is maxi.cex._api
+
+
+@mock_http_response(responses.GET, "/api/v1/telegram/channels", _CHANNELS)
+def test_telegram_mounted_channels_work():
+    maxi = Datamaxi(api_key="key", base_url=BASE_URL)
+    res, next_request = maxi.telegram.channels()
+    assert res == _CHANNELS
+    assert callable(next_request)
+
+
+@mock_http_response(responses.GET, "/api/v1/telegram/messages", _MESSAGES)
+def test_telegram_mounted_messages_work():
+    maxi = Datamaxi(api_key="key", base_url=BASE_URL)
+    res, next_request = maxi.telegram.messages(channel_name="alpha")
+    assert res == _MESSAGES
+    assert callable(next_request)

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -103,9 +103,6 @@ def test_messages_server_error():
         _client().messages(channel_name="alpha")
 
 
-# --- mounted sub-resource on Datamaxi (see #184) ---
-
-
 def test_telegram_mounted_reuses_shared_session():
     maxi = Datamaxi(api_key="key", base_url=BASE_URL)
     assert isinstance(maxi.telegram, Telegram)


### PR DESCRIPTION
Closes #184

## Summary

Mount `Telegram` and `Naver` as sub-resources on `Datamaxi` / `AsyncDatamaxi` (`maxi.telegram`, `maxi.naver`) so they reuse the client's one shared `requests.Session` / `httpx.AsyncClient` like every other resource. Previously they were standalone-only clients each opening their own transport.

- `Telegram`/`Naver` (+ async `AsyncTelegram`/`AsyncNaver`) now accept a shared `api=` (mounted path) or build their own from `api_key` (standalone path), following the `Resource` idiom.
- Mounted in both `Datamaxi.__init__` and `AsyncDatamaxi.__init__` with the client's shared `api`.
- Standalone `Telegram()` / `Naver()` / `AsyncTelegram()` / `AsyncNaver()` stay exported and functional (back-compat).
- README Clients table, sync/async quickstarts, and Telegram/Naver REST examples updated to the mounted form.

## Test plan

- Added sync tests: `maxi.telegram` / `maxi.naver` exist, are correct types, share the same `_api` as `maxi.cex`, and `channels`/`messages`/`trend` work against mocked responses.
- Added async tests (httpx.MockTransport): same identity + mounted `telegram`/`naver` calls work.
- Existing standalone telegram/naver tests still pass (back-compat).
- Full offline suite: `pytest -m "not integration"` -> 233 passed, 11 skipped.
- `black --check` + `flake8` clean on changed files.

No known failures.