### PR TITLE
docs(readme): drop standalone Telegram/Naver client mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ from datamaxi import Datamaxi
 # Alternatively, pass api_key="your_api_key" explicitly.
 maxi = Datamaxi()
 
-# Telegram and Naver are mounted as `maxi.telegram` / `maxi.naver`
-# (standalone `Telegram` / `Naver` clients remain available too).
+# Telegram and Naver are mounted as `maxi.telegram` / `maxi.naver`.
 channels, _ = maxi.telegram.channels()
 trend = maxi.naver.trend(symbol="BTC")
 
@@ -191,14 +190,12 @@ The package ships these clients, all configured the same way (see
 
 | Client            | Import                                        | Purpose                                                    |
 | ----------------- | --------------------------------------------- | ---------------------------------------------------------- |
-| `Datamaxi`        | `from datamaxi import Datamaxi`               | Synchronous client for all REST data, incl. `maxi.telegram` / `maxi.naver`. |
+| `Datamaxi`        | `from datamaxi import Datamaxi`               | Synchronous client for all REST data. |
 | `AsyncDatamaxi`   | `from datamaxi.aio import AsyncDatamaxi`      | Async twin of `Datamaxi` (needs the `[async]` extra).      |
 | `AsyncDatamaxiWS` | `from datamaxi.aio.ws import AsyncDatamaxiWS` | Async WebSocket streaming (needs the `[ws]` extra).        |
 
 Telegram and Naver are mounted on `Datamaxi` / `AsyncDatamaxi` (`maxi.telegram`,
-`maxi.naver`) so they reuse the client's shared session. The standalone
-`Telegram` / `Naver` (and their async twins `AsyncTelegram` / `AsyncNaver`,
-imported from `datamaxi.aio`) remain available for independent use.
+`maxi.naver`) so they reuse the client's shared session.
 
 ## REST API Reference
 


### PR DESCRIPTION
Removes the three README references advertising the standalone `Telegram` / `Naver` / `AsyncTelegram` / `AsyncNaver` clients as an alternative access path, per the "don't advertise back-compat" doc preference. Docs-only.

Removed:
1. Quickstart Sync comment `(standalone Telegram / Naver clients remain available too)`.
2. Clients table: `, incl. maxi.telegram / maxi.naver` from the `Datamaxi` row.
3. The sentence stating the standalone `Telegram` / `Naver` (+ async twins) remain available for independent use.

The mount sentence (`maxi.telegram` / `maxi.naver` reuse the shared session) is kept.

## Note (investigation, item 4)
The standalone classes are **not** removed from code — only the doc mentions. `from datamaxi import Telegram` / `Naver` and `from datamaxi.aio import AsyncTelegram` / `AsyncNaver` still work, and `maxi.telegram` is literally an instance of that same `Telegram` class (`resources/__init__.py:72`, `aio/__init__.py:73`). So they *are* still usable as separate clients. If we actually want to drop that, it's a separate code-change PR.

## Tests
Docs-only; no tests run.