### PR TITLE
Sync generated WS files with backend AsyncAPI spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,6 @@ you can also read the expected shape at runtime via `ws.<channel>.param_format`.
 | `ws.liquidation`            | `subscribe(*p)`                             | `SYMBOL@exchange`                                    | Basic |
 | `ws.liquidation_feed`       | `stream()`                                  | — (firehose, no params)                             | Basic |
 | `ws.announcement`           | `subscribe()`                               | — (no params)                                       | Pro+  |
-| `ws.announcement_internal`  | `subscribe()`                               | — (no params)                                       | Pro+  |
 
 ### Multiplexing and filtering
 

--- a/datamaxi/_ws_endpoints.py
+++ b/datamaxi/_ws_endpoints.py
@@ -19,14 +19,6 @@ WS_CHANNELS = {
         "subscribe": True,
         "unsubscribe": True,
     },
-    "/announcement/listing/internal": {
-        "plan": "pro_plus",
-        "market": None,
-        "message": "InternalListingMessage",
-        "param": None,
-        "subscribe": True,
-        "unsubscribe": True,
-    },
     "/forex": {
         "plan": "basic",
         "market": None,

--- a/datamaxi/_ws_models.py
+++ b/datamaxi/_ws_models.py
@@ -63,21 +63,6 @@ FundingRateMessage = TypedDict(
 
 
 # source: asyncapi:payload
-InternalListingMessage = TypedDict(
-    "InternalListingMessage",
-    {
-        "b": str,
-        "d": int,
-        "e": str,
-        "s": str,
-        "t": str,
-        "u": str,
-    },
-    total=False,
-)
-
-
-# source: asyncapi:payload
 LiquidationMessage = TypedDict(
     "LiquidationMessage",
     {

--- a/datamaxi/aio/ws.py
+++ b/datamaxi/aio/ws.py
@@ -23,7 +23,7 @@ Usage::
 Channels (accessors driven by the generated ``WS_CHANNELS`` registry):
 ``ticker`` (market-keyed), ``forex``, ``premium``, ``funding_rate``,
 ``open_interest``, ``liquidation`` (subscribe), ``liquidation_feed``
-(firehose, no params), ``announcement`` / ``announcement_internal`` (Pro+).
+(firehose, no params), ``announcement`` (Pro+).
 
 Consumes the **generated** WS surface — ``WS_CHANNELS`` / ``WS_BASE_PATH`` /
 ``WS_AUTH_HEADER`` from ``datamaxi._ws_endpoints`` and the per-channel message
@@ -419,7 +419,7 @@ class AsyncDatamaxiWS:
     Accessors are driven by the generated ``WS_CHANNELS`` registry:
     ``ticker`` (market-keyed), ``forex``, ``premium``, ``funding_rate``,
     ``open_interest``, ``liquidation`` (subscribe), ``liquidation_feed``
-    (firehose), ``announcement`` / ``announcement_internal`` (Pro+).
+    (firehose), ``announcement`` (Pro+).
 
     Use as an async context manager so open connections are closed, or call
     :meth:`aclose` explicitly.
@@ -449,9 +449,6 @@ class AsyncDatamaxiWS:
         self.liquidation = Subscription(self, "/liquidation")
         self.liquidation_feed = Feed(self, "/liquidation/feed")
         self.announcement = Subscription(self, "/announcement/listing")
-        self.announcement_internal = Subscription(
-            self, "/announcement/listing/internal"
-        )
 
     async def _conn(self, path: str) -> AsyncWSConnection:
         conn = self._conns.get(path)

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -53,7 +53,6 @@ strings shown below; you can also inspect the expected format at runtime via
 | `ws.liquidation`            | `subscribe(*p)`                             | `SYMBOL@exchange`                                    | Basic |
 | `ws.liquidation_feed`       | `stream()`                                  | — (firehose, no params)                             | Basic |
 | `ws.announcement`           | `subscribe()`                               | — (no params)                                       | Pro+  |
-| `ws.announcement_internal`  | `subscribe()`                               | — (no params)                                       | Pro+  |
 
 `ticker` is market-keyed — pass `market="spot"` (default) or `market="futures"`.
 The announcement channels require a **Pro+** plan.

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -63,7 +63,6 @@ def test_ws_every_channel_has_a_generated_model_and_accessor():
         "liquidation",
         "liquidation_feed",
         "announcement",
-        "announcement_internal",
     ):
         assert hasattr(ws, name), f"client missing ws.{name}"
 


### PR DESCRIPTION
Automated WebSocket generated-file sync from **datamaxi-codegen**.

The committed `datamaxi/_ws_endpoints.py` / `datamaxi/_ws_models.py`
had drifted from the current `Bisonai/datamaxi-backend`
`ws-asyncapi.yaml` spec (+ message schemas). This PR regenerates them
via `make update-ws-python`.

Triggering codegen run:
https://github.com/Bisonai/datamaxi-codegen/actions/runs/28776391498

Do not edit these files by hand — they are generated.