### PR TITLE
Sync generated _endpoints.py with backend spec

### DIFF
--- a/datamaxi/_endpoints.py
+++ b/datamaxi/_endpoints.py
@@ -105,14 +105,14 @@ ENDPOINTS = {
             "from": {
                 "required": False,
                 "in": "query",
-                "type": "str",
-                "description": "Specifies from",
+                "type": "int",
+                "description": "Specifies from (unix seconds)",
             },
             "to": {
                 "required": False,
                 "in": "query",
-                "type": "str",
-                "description": "Specifies to",
+                "type": "int",
+                "description": "Specifies to (unix seconds)",
             },
         },
     },


### PR DESCRIPTION
Automated registry sync from **datamaxi-codegen**.

The committed `datamaxi/_endpoints.py` had drifted from the current
`Bisonai/datamaxi-backend` OpenAPI spec. This PR regenerates it via
`make update-python`.

Triggering codegen run:
https://github.com/Bisonai/datamaxi-codegen/actions/runs/28840334932

Do not edit `_endpoints.py` by hand — it is generated. Re-run the
codegen workflow to refresh.