### PR TITLE
Sync generated WS files with backend AsyncAPI spec

### DIFF
--- a/datamaxi/_ws_endpoints.py
+++ b/datamaxi/_ws_endpoints.py
@@ -35,14 +35,6 @@ WS_CHANNELS = {
         "subscribe": False,
         "unsubscribe": False,
     },
-    "/front/listing/deposit": {
-        "plan": "front",
-        "market": None,
-        "message": "DepositListingMessage",
-        "param": None,
-        "subscribe": True,
-        "unsubscribe": True,
-    },
     "/funding-rate": {
         "plan": "basic",
         "market": None,

--- a/datamaxi/_ws_models.py
+++ b/datamaxi/_ws_models.py
@@ -13,27 +13,6 @@ from typing import Any, Dict, List, TypedDict  # noqa: F401
 
 
 # source: asyncapi:payload
-DepositListingMessage = TypedDict(
-    "DepositListingMessage",
-    {
-        "amount": float,
-        "amount_krw": float,
-        "amount_usd": float,
-        "asset": str,
-        "block_number": int,
-        "chain": str,
-        "exchange": str,
-        "from_address": str,
-        "timestamp": int,
-        "to_address": str,
-        "tx_hash": str,
-        "type": int,
-    },
-    total=False,
-)
-
-
-# source: asyncapi:payload
 ForexMessage = TypedDict(
     "ForexMessage",
     {


### PR DESCRIPTION
Automated WebSocket generated-file sync from **datamaxi-codegen**.

The committed `datamaxi/_ws_endpoints.py` / `datamaxi/_ws_models.py`
had drifted from the current `Bisonai/datamaxi-backend`
`ws-asyncapi.yaml` spec (+ message schemas). This PR regenerates them
via `make update-ws-python`.

Triggering codegen run:
https://github.com/Bisonai/datamaxi-codegen/actions/runs/28849393649

Do not edit these files by hand — they are generated.