### PR TITLE
Sync generated _endpoints.py with backend spec

### DIFF
--- a/datamaxi/_endpoints.py
+++ b/datamaxi/_endpoints.py
@@ -100,6 +100,7 @@ ENDPOINTS = {
                 "in": "query",
                 "type": "str",
                 "default": "1d",
+                "enum": ["1m", "5m", "15m", "1h", "4h", "12h", "1d"],
                 "description": "Specifies interval",
             },
             "from": {
@@ -646,6 +647,7 @@ ENDPOINTS = {
                 "in": "query",
                 "type": "str",
                 "default": "5m",
+                "enum": ["5m", "15m", "1h", "4h", "12h", "1d"],
                 "description": "interval",
             },
         },


### PR DESCRIPTION
Automated registry sync from **datamaxi-codegen**.

The committed `datamaxi/_endpoints.py` had drifted from the current
`Bisonai/datamaxi-backend` OpenAPI spec. This PR regenerates it via
`make update-python`.

Triggering codegen run:
https://github.com/Bisonai/datamaxi-codegen/actions/runs/28853821588

Do not edit `_endpoints.py` by hand — it is generated. Re-run the
codegen workflow to refresh.