### PR TITLE
Sync generated _endpoints.py with backend spec

### DIFF
--- a/datamaxi/_endpoints.py
+++ b/datamaxi/_endpoints.py
@@ -368,7 +368,7 @@ ENDPOINTS = {
                 "required": False,
                 "in": "query",
                 "type": "str",
-                "description": "Exchange filter (narrows the Redis scan)",
+                "description": "Exchange filter (narrows to a single venue)",
             },
         },
     },


### PR DESCRIPTION
Automated registry sync from **datamaxi-codegen**.

The committed `datamaxi/_endpoints.py` had drifted from the current
`Bisonai/datamaxi-backend` OpenAPI spec. This PR regenerates it via
`make update-python`.

Triggering codegen run:
https://github.com/Bisonai/datamaxi-codegen/actions/runs/28932335465

Do not edit `_endpoints.py` by hand — it is generated. Re-run the
codegen workflow to refresh.