### PR TITLE
Sync generated _endpoints.py with backend spec

### DIFF
--- a/datamaxi/_endpoints.py
+++ b/datamaxi/_endpoints.py
@@ -1355,13 +1355,6 @@ ENDPOINTS = {
                 "enum": ["USD", "USDT"],
                 "description": "Specifies conversion base applied to price values",
             },
-            "include_source": {
-                "required": False,
-                "in": "query",
-                "type": "bool",
-                "default": False,
-                "description": "When true, include the frame's transport source (ws|rest) in the response.",
-            },
         },
     },
     "ticker_exchanges": {

--- a/datamaxi/_responses.py
+++ b/datamaxi/_responses.py
@@ -1253,8 +1253,6 @@ class TickerResponse:
     currency: str = ""
     data: Optional[TickerView] = None
     market: str = ""
-    # Source is populated only when ?include_source=true; omitempty drops the key for default callers, preserving the pre-Phase-1 JSON byte shape (strict-decoder safe).
-    src: Any = None
 
     @classmethod
     def from_dict(cls, data: dict) -> TickerResponse:
@@ -1262,7 +1260,6 @@ class TickerResponse:
             currency=data.get("currency", ""),
             data=_as_model(TickerView, data.get("data")),
             market=data.get("market", ""),
-            src=data.get("src"),
         )
 
 

--- a/datamaxi/aio/_core.py
+++ b/datamaxi/aio/_core.py
@@ -72,7 +72,7 @@ class AsyncAPI:
 
     async def send_request(self, method, url_path, payload=None):
         # str()-encode scalars so bools match the sync client's urlencode
-        # output (e.g. include_source -> "True", not httpx's "true").
+        # output (e.g. a bool param -> "True", not httpx's "true").
         params = {k: str(v) for k, v in (payload or {}).items() if v is not None}
         attempt = 0
         while True:

--- a/datamaxi/aio/cex.py
+++ b/datamaxi/aio/cex.py
@@ -99,7 +99,6 @@ class AsyncCexTicker(AsyncResource):
         market: Market,
         currency: Optional[str] = None,
         conversion_base: Optional[str] = None,
-        include_source: bool = False,
         pandas: bool = True,
     ) -> Union[pd.DataFrame, TickerResponse]:
         """Fetch ticker data (async). See ``datamaxi.Datamaxi.cex.ticker``."""
@@ -120,7 +119,6 @@ class AsyncCexTicker(AsyncResource):
             market=market,
             currency=currency,
             conversion_base=conversion_base,
-            include_source=include_source,
         )
 
         if pandas:

--- a/datamaxi/resources/cex_ticker.py
+++ b/datamaxi/resources/cex_ticker.py
@@ -30,7 +30,6 @@ class CexTicker(Resource):
         market: Market,
         currency: Optional[str] = None,
         conversion_base: Optional[str] = None,
-        include_source: bool = False,
         pandas: bool = True,
     ) -> Union[pd.DataFrame, TickerResponse]:
         """Fetch ticker data
@@ -45,8 +44,6 @@ class CexTicker(Resource):
             market (str): Market type (spot/futures)
             currency (str): Price currency
             conversion_base (str): Conversion base currency
-            include_source (bool): Include the frame's transport source
-                (``ws``|``rest``) in the response
             pandas (bool): Return data as pandas DataFrame
 
         Returns:
@@ -71,7 +68,6 @@ class CexTicker(Resource):
             market=market,
             currency=currency,
             conversion_base=conversion_base,
-            include_source=include_source,
         )
 
         if pandas:

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -59,28 +59,6 @@ def test_async_candle_pandas_false_returns_envelope():
     assert res == _CANDLE
 
 
-def test_async_ticker_forwards_bool_param_like_sync():
-    seen = {}
-
-    def handler(request):
-        seen.update(dict(request.url.params))
-        return httpx.Response(200, json=_TICKER)
-
-    async def run():
-        async with _client(handler) as c:
-            return await c.cex.ticker.get(
-                exchange="binance",
-                market="spot",
-                symbol="BTC-USDT",
-                include_source=True,
-            )
-
-    df = _run(run())
-    assert isinstance(df, pd.DataFrame)
-    # bool encoded as "True" (matches the sync urlencode output), not "true"
-    assert seen["include_source"] == "True"
-
-
 def test_async_last_response_populated():
     headers = {"x-ratelimit-remaining": "42"}
 

--- a/tests/test_cex_ticker.py
+++ b/tests/test_cex_ticker.py
@@ -52,24 +52,6 @@ def test_ticker_get_sends_query_params():
     assert qs["conversion_base"] == ["USDT"]
 
 
-@responses.activate
-def test_ticker_get_forwards_include_source():
-    responses.add(
-        responses.GET,
-        re.compile(".*/api/v1/ticker.*"),
-        json=_TICKER,
-        status=200,
-    )
-    _client().get(
-        exchange="binance",
-        market="spot",
-        symbol="BTC-USDT",
-        include_source=True,
-    )
-    qs = _qs(responses.calls[0])
-    assert qs["include_source"] == ["True"]
-
-
 def test_ticker_invalid_market_raises_value_error():
     with pytest.raises(ValueError):
         _client().get(exchange="binance", market="bogus", symbol="BTC-USDT")


### PR DESCRIPTION
Automated registry sync from **datamaxi-codegen**.

The committed `datamaxi/_endpoints.py` had drifted from the current
`Bisonai/datamaxi-backend` OpenAPI spec. This PR regenerates it via
`make update-python`.

Triggering codegen run:
https://github.com/Bisonai/datamaxi-codegen/actions/runs/29408527416

Do not edit `_endpoints.py` by hand — it is generated. Re-run the
codegen workflow to refresh.